### PR TITLE
Implement 'ack' and 'nack' client frames

### DIFF
--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -87,6 +87,14 @@ class StompClient {
         headers: headers);
   }
 
+  void ack({@required id, Map<String, String> headers}) {
+    _handler.ack(id: id, headers: headers);
+  }
+
+  void nack({@required id, Map<String, String> headers}) {
+    _handler.nack(id: id, headers: headers);
+  }
+
   void _scheduleReconnect() {
     _reconnectTimer?.cancel();
 

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -93,6 +93,18 @@ class StompHandler {
         command: 'SEND', body: body, binaryBody: binaryBody, headers: headers);
   }
 
+  void ack({@required id, Map<String, String> headers}) {
+    headers = headers ?? {};
+    headers['id'] = id;
+    _transmit(command: 'ACK', headers: headers);
+  }
+
+  void nack({@required id, Map<String, String> headers}) {
+    headers = headers ?? {};
+    headers['id'] = id;
+    _transmit(command: 'NACK', headers: headers);
+  }
+
   void watchForReceipt(String receiptId, Function(StompFrame) callback) {
     _receiptWatchers[receiptId] = callback;
   }


### PR DESCRIPTION
Hi!

First of all, thanks for this neat little library! I noticed this library does not support 'ACK', as well as 'NACK' client frames yet. Since I have a use for them, I took the liberty to implement them in this pull request.

Both 'ack' and 'nack' are implemented as siblings to the send method, since according to the [spec](https://stomp.github.io/stomp-specification-1.2.html#SUBSCRIBE_ack_Header) the client is basically free to send 'ack' and 'nack' whenever it feels like it. Therefore, I did not go with automatic acknowledge or similar. Furthermore, this fits quite well with the current structure, I think.

I'd be happy If you'd merge this PR. Let me know what you think.
Thanks! 
:smiley: 