### PR TITLE
Fix missing explicit type on ack/nack handlers

### DIFF
--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -87,11 +87,11 @@ class StompClient {
         headers: headers);
   }
 
-  void ack({@required id, Map<String, String> headers}) {
+  void ack({@required String id, Map<String, String> headers}) {
     _handler.ack(id: id, headers: headers);
   }
 
-  void nack({@required id, Map<String, String> headers}) {
+  void nack({@required String id, Map<String, String> headers}) {
     _handler.nack(id: id, headers: headers);
   }
 

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -93,13 +93,13 @@ class StompHandler {
         command: 'SEND', body: body, binaryBody: binaryBody, headers: headers);
   }
 
-  void ack({@required id, Map<String, String> headers}) {
+  void ack({@required String id, Map<String, String> headers}) {
     headers = headers ?? {};
     headers['id'] = id;
     _transmit(command: 'ACK', headers: headers);
   }
 
-  void nack({@required id, Map<String, String> headers}) {
+  void nack({@required String id, Map<String, String> headers}) {
     headers = headers ?? {};
     headers['id'] = id;
     _transmit(command: 'NACK', headers: headers);


### PR DESCRIPTION
Thanks for merging the last PR! 😃 
Unfortunately, I noticed that I somehow accidentally omitted the type for the id parameter on both methods in the client, as well as the handler. This PR fixes that.