### PR TITLE
Allow beforeConnect callback to provide new StompConfig

### DIFF
--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -28,9 +28,11 @@ class StompConfig {
   /// Headers to be passed when connecting to WebSocket
   final Map<String, dynamic> webSocketConnectHeaders;
 
-  /// Asynchronous function to be executed before we connect
-  /// the socket
-  final Future<void> Function() beforeConnect;
+  /// Asynchronous function to be executed before we connect the socket.
+  ///
+  /// Allows overwriting the config before a connection attempt is made.
+  /// Return null to not overwrite the config
+  final Future<StompConfig> Function() beforeConnect;
 
   /// Callback for when STOMP has successulfy connected
   final Function(StompClient, StompFrame) onConnect;
@@ -87,7 +89,7 @@ class StompConfig {
           Duration connectionTimeout,
           Map<String, String> stompConnectHeaders,
           Map<String, dynamic> webSocketConnectHeaders,
-          Future<void> Function() beforeConnect,
+          Future<StompConfig> Function() beforeConnect,
           Function(StompClient, StompFrame) onConnect,
           Function(StompFrame) onStompError,
           Function(StompFrame) onDisconnect,
@@ -116,5 +118,5 @@ class StompConfig {
           onWebSocketDone: onWebSocketDone ?? this.onWebSocketDone);
 
   static void _noOp([_, __]) => null;
-  static Future<dynamic> _noOpFuture() => null;
+  static Future<StompConfig> _noOpFuture() => null;
 }

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -32,7 +32,7 @@ class StompConfig {
   ///
   /// Allows overwriting the config before a connection attempt is made.
   /// Return null to not overwrite the config
-  final Future<StompConfig> Function() beforeConnect;
+  final FutureOr<StompConfig> Function() beforeConnect;
 
   /// Callback for when STOMP has successulfy connected
   final Function(StompClient, StompFrame) onConnect;
@@ -89,7 +89,7 @@ class StompConfig {
           Duration connectionTimeout,
           Map<String, String> stompConnectHeaders,
           Map<String, dynamic> webSocketConnectHeaders,
-          Future<StompConfig> Function() beforeConnect,
+          FutureOr<StompConfig> Function() beforeConnect,
           Function(StompClient, StompFrame) onConnect,
           Function(StompFrame) onStompError,
           Function(StompFrame) onDisconnect,
@@ -118,5 +118,5 @@ class StompConfig {
           onWebSocketDone: onWebSocketDone ?? this.onWebSocketDone);
 
   static void _noOp([_, __]) => null;
-  static Future<StompConfig> _noOpFuture() => null;
+  static FutureOr<StompConfig> _noOpFuture() => null;
 }

--- a/test/stomp_test.dart
+++ b/test/stomp_test.dart
@@ -147,5 +147,178 @@ void main() {
 
       client.activate();
     });
+
+    test('should try updating config sync before connect', () async {
+      var streamChannel = spawnHybridCode(r'''
+        import 'dart:io';
+        import 'dart:async';
+        import 'package:web_socket_channel/io.dart';
+        import 'package:stomp_dart_client/stomp_parser.dart';
+        import 'package:stream_channel/stream_channel.dart';
+
+        hybridMain(StreamChannel channel) async {
+          HttpServer server = await HttpServer.bind('localhost', 0);
+          server.transform(WebSocketTransformer()).listen((webSocket) {
+            var channel = IOWebSocketChannel(webSocket);
+            int n = 0;
+            channel.stream.listen((request) {
+              if (n == 0) {
+                if (!request.startsWith("CONNECT")) {
+                  channel.sink.close();
+                }
+                channel.sink.add("CONNECTED\nversion:1.2\n\n\x00");
+              } else {
+                if (request.startsWith("DISCONNECT")) {
+                  channel.sink.add("RECEIPT\nreceipt-id:disconnect-0\n\n\x00");
+                  channel.sink.close();
+                }
+              }
+              n++;
+            });
+          });
+
+          channel.sink.add(server.port);
+        }
+      ''', stayAlive: true);
+
+      int port = await streamChannel.stream.first;
+
+      dynamic onConnected = expectAsync2((StompClient client, _) {
+        final header = client.config.webSocketConnectHeaders['test'];
+        expect(client.config.url, 'ws://localhost:$port');
+        expect(header, 'after-connect-attempt');
+      });
+
+      StompConfig config;
+      config = StompConfig(
+        url: 'ws://localhost:$port',
+        webSocketConnectHeaders: {'test': 'before-connect-attempt'},
+        beforeConnect: () {
+          return config.copyWith(
+            onConnect: onConnected,
+            webSocketConnectHeaders: {'test': 'after-connect-attempt'},
+          );
+        },
+      );
+
+      final client = StompClient(config: config);
+      final header = client.config.webSocketConnectHeaders['test'];
+      expect(header, 'before-connect-attempt');
+      client.activate();
+    });
+
+    test('should try updating config async before connect', () async {
+      var streamChannel = spawnHybridCode(r'''
+        import 'dart:io';
+        import 'dart:async';
+        import 'package:web_socket_channel/io.dart';
+        import 'package:stomp_dart_client/stomp_parser.dart';
+        import 'package:stream_channel/stream_channel.dart';
+
+        hybridMain(StreamChannel channel) async {
+          HttpServer server = await HttpServer.bind('localhost', 0);
+          server.transform(WebSocketTransformer()).listen((webSocket) {
+            var channel = IOWebSocketChannel(webSocket);
+            int n = 0;
+            channel.stream.listen((request) {
+              if (n == 0) {
+                if (!request.startsWith("CONNECT")) {
+                  channel.sink.close();
+                }
+                channel.sink.add("CONNECTED\nversion:1.2\n\n\x00");
+              } else {
+                if (request.startsWith("DISCONNECT")) {
+                  channel.sink.add("RECEIPT\nreceipt-id:disconnect-0\n\n\x00");
+                  channel.sink.close();
+                }
+              }
+              n++;
+            });
+          });
+
+          channel.sink.add(server.port);
+        }
+      ''', stayAlive: true);
+
+      int port = await streamChannel.stream.first;
+
+      dynamic onConnected = expectAsync2((StompClient client, _) {
+        final header = client.config.webSocketConnectHeaders['test'];
+        expect(header, 'after-connect-attempt');
+      });
+
+      StompConfig config;
+      config = StompConfig(
+        url: 'ws://localhost:$port',
+        webSocketConnectHeaders: {'test': 'before-connect-attempt'},
+        beforeConnect: () async {
+          await Future.delayed(Duration(milliseconds: 200));
+          return config.copyWith(
+            onConnect: onConnected,
+            webSocketConnectHeaders: {'test': 'after-connect-attempt'},
+          );
+        },
+      );
+
+      final client = StompClient(config: config);
+      final header = client.config.webSocketConnectHeaders['test'];
+      expect(header, 'before-connect-attempt');
+      client.activate();
+    });
+
+    test('should not update config when given null before connect', () async {
+      var streamChannel = spawnHybridCode(r'''
+        import 'dart:io';
+        import 'dart:async';
+        import 'package:web_socket_channel/io.dart';
+        import 'package:stomp_dart_client/stomp_parser.dart';
+        import 'package:stream_channel/stream_channel.dart';
+
+        hybridMain(StreamChannel channel) async {
+          HttpServer server = await HttpServer.bind('localhost', 0);
+          server.transform(WebSocketTransformer()).listen((webSocket) {
+            var channel = IOWebSocketChannel(webSocket);
+            int n = 0;
+            channel.stream.listen((request) {
+              if (n == 0) {
+                if (!request.startsWith("CONNECT")) {
+                  channel.sink.close();
+                }
+                channel.sink.add("CONNECTED\nversion:1.2\n\n\x00");
+              } else {
+                if (request.startsWith("DISCONNECT")) {
+                  channel.sink.add("RECEIPT\nreceipt-id:disconnect-0\n\n\x00");
+                  channel.sink.close();
+                }
+              }
+              n++;
+            });
+          });
+
+          channel.sink.add(server.port);
+        }
+      ''', stayAlive: true);
+
+      int port = await streamChannel.stream.first;
+
+      dynamic onConnected = expectAsync2((StompClient client, _) {
+        final header = client.config.webSocketConnectHeaders['test'];
+        expect(client.config.url, 'ws://localhost:$port');
+        expect(header, 'before-connect-attempt');
+      });
+
+      StompConfig config;
+      config = StompConfig(
+        url: 'ws://localhost:$port',
+        webSocketConnectHeaders: {'test': 'before-connect-attempt'},
+        beforeConnect: () => null,
+        onConnect: onConnected,
+      );
+
+      final client = StompClient(config: config);
+      final header = client.config.webSocketConnectHeaders['test'];
+      expect(header, 'before-connect-attempt');
+      client.activate();
+    });
   });
 }

--- a/test/stomp_test.dart
+++ b/test/stomp_test.dart
@@ -10,7 +10,7 @@ void main() {
 
     tearDown(() async {});
     test('should not be connected on creation', () {
-      final client = StompClient(config: null);
+      final client = StompClient(config: StompConfig(url: null));
       expect(client.connected, false);
     });
 


### PR DESCRIPTION
This PR allows the user to return a new StompConfig from the beforeConnect callback. This is accomplished by hiding the public config on the StompClient behind a property and introducing a private `_client` field. This field is overwritten by the beforeConnect callback when a non-null config is returned.

**Use Case**
When connecting to the WebSocket you might want so send an authorization header,  which currently looks something like this:

```
final client = StompClient(
  config: StompConfig(
    url: "wss://something",
    webSocketConnectHeaders:  {"Authorization": "Bearer MyAuthToken"},
  },
}
```

This works fine, as long as the token never changes. In reality, JWT tokens (should) expire after a set amount of time and the client might need to (asynchronously) fetch a new token from an external service first. If the connection now drops, and the client tries to reconnect it still tries to authenticate with the old, now expired, token, hence trying to indefintely reconnect (and failing). With this PR the user can now do something like this:
```
StompConfig config;
config = StompConfig(
  url: "wss://something",
  beforeConnect: () async {
    var token = await getMyAuthToken();
    return config.copyWith(
      webSocketConnectHeaders: {"Authorization": "Bearer $token"});
  },
);

final client = StompClient(config: config);
```

In my opinion this neatly solves the problem without major changes and the token can now automatically be refreshed in the background. I also provided tests, that check whether the new config is applied correctly before a connection attempt. 
Note that this is a potentially breaking change, since the return type of beforeConnect changes. If somebody passed an anonymous function to beforeConnect it will give linter warnings and run anyway. But, if somebody defined a function with void return type it will not compile. I think.
