### PR TITLE
Reconnect websocket when `WebSocketException` occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.6
+ - Reconnect websocket when `WebSocketException` occurs if reconnectDelay != 0
+ 
 ## 0.3.5
  - Prevent `StompConfig` from losing `onDebugMessage` callback on `copyWith` #22
 

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -45,7 +45,12 @@ class StompHandler {
       channel.stream.listen(_onData, onError: _onError, onDone: _onDone);
       _connectToStomp();
     } on WebSocketChannelException catch (err) {
-      _onError(err);
+      if (config.reconnectDelay == 0) {
+        _onError(err);
+      } else {
+        config.onDebugMessage('Connection error...reconnecting');
+        _onDone();
+      }
     } on TimeoutException catch (err) {
       if (config.reconnectDelay == 0) {
         _onError(err);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stomp_dart_client
 homepage: https://github.com/blackhorse-one/stomp_dart
-version: 0.3.5
+version: 0.3.6
 description: Dart STOMP client for easy messaging interoperability. Build with flutter in mind, but should work for every dart application.
 environment:
   sdk: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
If reconnect delay is not equals to 0, the stomp_handler must launch new connect.

link to issue #23 