### PR TITLE
for the socketjs, ping payload is strictly limited to ["\n" ] 

### DIFF
--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -260,7 +260,11 @@ class StompHandler {
       _heartbeatSender?.cancel();
       _heartbeatSender = Timer.periodic(Duration(milliseconds: ttl), (_) {
         config.onDebugMessage('>>> PING');
-        channel.sink.add('\n');
+        if (config.useSockJS) {
+          channel.sink.add('[\\n]');
+        } else {
+          channel.sink.add('\n');
+        }
       });
     }
 

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -261,7 +261,7 @@ class StompHandler {
       _heartbeatSender = Timer.periodic(Duration(milliseconds: ttl), (_) {
         config.onDebugMessage('>>> PING');
         if (config.useSockJS) {
-          channel.sink.add('[\\n]');
+          channel.sink.add('["\\n"]');
         } else {
           channel.sink.add('\n');
         }


### PR DESCRIPTION
for the socketjs, ping payload is strictly limited to ["\n" ] in the websocket backend implemented with spring framework 
so we have to change it to same data format so that the connection is not closed because of protocol error.