### PR TITLE
remove trailing # from generated transport Url

### DIFF
--- a/lib/sock_js/sock_js_utils.dart
+++ b/lib/sock_js/sock_js_utils.dart
@@ -21,11 +21,12 @@ class SockJsUtils {
     pathSegments.add('websocket');
 
     uri = Uri(
-        scheme: uri.scheme,
-        host: uri.host,
-        port: uri.port,
-        fragment: uri.fragment,
-        pathSegments: pathSegments);
+      scheme: uri.scheme,
+      host: uri.host,
+      port: uri.port,
+      fragment: null,
+      pathSegments: pathSegments,
+    );
 
     var transportUrl = uri.toString();
     if (transportUrl.startsWith('https')) {

--- a/test/sock_js_utils_test.dart
+++ b/test/sock_js_utils_test.dart
@@ -23,11 +23,20 @@ void main() {
       expect(webSocketUrl.startsWith('wss://'), isTrue);
     });
 
+    test('generate websocket url with no empty fragment', () {
+      final url = 'https://localhost:5000/test';
+
+      final webSocketUrl = SockJsUtils().generateTransportUrl(url);
+
+      expect(webSocketUrl, isNotNull);
+      expect(webSocketUrl, isNotEmpty);
+      expect(webSocketUrl.endsWith('#'), isFalse);
+    });
+
     test('generate websocket url with bad url', () {
       final url = 'wss://localhost:5000/test';
 
-      expect(
-          () => SockJsUtils().generateTransportUrl(url), throwsArgumentError);
+      expect(() => SockJsUtils().generateTransportUrl(url), throwsArgumentError);
     });
   });
 }


### PR DESCRIPTION
Removes to trailing '#' from the generated transport url of SockJs

link to issue #32 