### PR TITLE
add query support in sockjs

### DIFF
--- a/lib/sock_js/sock_js_utils.dart
+++ b/lib/sock_js/sock_js_utils.dart
@@ -24,6 +24,7 @@ class SockJsUtils {
       scheme: uri.scheme,
       host: uri.host,
       port: uri.port,
+      query: uri.query,
       fragment: null,
       pathSegments: pathSegments,
     );


### PR DESCRIPTION
There are times when we need a socket url like this.
"http://host.com:8011/myUrl?name=somebody'.