### PR TITLE
Null safety migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://www.dartlang.org/guides/libraries/private-files
+.idea/
 
 # Files and directories created by pub
 .dart_tool/

--- a/TODO
+++ b/TODO
@@ -15,4 +15,4 @@ Todo:
   ✔ Ack/Nack @done(20-04-08 23:59)
   ☐ Make Ack/Nack compliant with 1.0 and 1.1
   ☐ Add .ack and .nack methods to the StompFrame for convenience
-  ☐ Change timeouts to Duration
+  ✔ Change timeouts to Duration

--- a/example/main.dart
+++ b/example/main.dart
@@ -5,16 +5,16 @@ import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_config.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 
-dynamic onConnect(StompClient client, StompFrame frame) {
-  client.subscribe(
+dynamic onConnect(StompClient? client, StompFrame frame) {
+  client?.subscribe(
       destination: '/topic/test/subscription',
       callback: (StompFrame frame) {
-        List<dynamic> result = json.decode(frame.body);
+        List<dynamic>? result = json.decode(frame.body!);
         print(result);
       });
 
   Timer.periodic(Duration(seconds: 10), (_) {
-    client.send(
+    client?.send(
         destination: '/app/test/endpoints', body: json.encode({'a': 123}));
   });
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -5,17 +5,20 @@ import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_config.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 
-dynamic onConnect(StompClient? client, StompFrame frame) {
+void onConnect(StompClient? client, StompFrame frame) {
   client?.subscribe(
-      destination: '/topic/test/subscription',
-      callback: (StompFrame frame) {
-        List<dynamic>? result = json.decode(frame.body!);
-        print(result);
-      });
+    destination: '/topic/test/subscription',
+    callback: (frame) {
+      List<dynamic>? result = json.decode(frame.body!);
+      print(result);
+    },
+  );
 
   Timer.periodic(Duration(seconds: 10), (_) {
     client?.send(
-        destination: '/app/test/endpoints', body: json.encode({'a': 123}));
+      destination: '/app/test/endpoints',
+      body: json.encode({'a': 123}),
+    );
   });
 }
 
@@ -23,6 +26,11 @@ final stompClient = StompClient(
   config: StompConfig(
     url: 'ws://localhost:8080',
     onConnect: onConnect,
+    beforeConnect: () async {
+      print('waiting to connect...');
+      await Future.delayed(Duration(milliseconds: 200));
+      print('connecting...');
+    },
     onWebSocketError: (dynamic error) => print(error.toString()),
     stompConnectHeaders: {'Authorization': 'Bearer yourToken'},
     webSocketConnectHeaders: {'Authorization': 'Bearer yourToken'},

--- a/example/main.dart
+++ b/example/main.dart
@@ -5,8 +5,8 @@ import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_config.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 
-void onConnect(StompClient? client, StompFrame frame) {
-  client?.subscribe(
+void onConnect(StompFrame frame) {
+  stompClient.subscribe(
     destination: '/topic/test/subscription',
     callback: (frame) {
       List<dynamic>? result = json.decode(frame.body!);
@@ -15,7 +15,7 @@ void onConnect(StompClient? client, StompFrame frame) {
   );
 
   Timer.periodic(Duration(seconds: 10), (_) {
-    client?.send(
+    stompClient.send(
       destination: '/app/test/endpoints',
       body: json.encode({'a': 123}),
     );

--- a/example/main.dart
+++ b/example/main.dart
@@ -20,12 +20,14 @@ dynamic onConnect(StompClient? client, StompFrame frame) {
 }
 
 final stompClient = StompClient(
-    config: StompConfig(
-        url: 'ws://localhost:8080',
-        onConnect: onConnect,
-        onWebSocketError: (dynamic error) => print(error.toString()),
-        stompConnectHeaders: {'Authorization': 'Bearer yourToken'},
-        webSocketConnectHeaders: {'Authorization': 'Bearer yourToken'}));
+  config: StompConfig(
+    url: 'ws://localhost:8080',
+    onConnect: onConnect,
+    onWebSocketError: (dynamic error) => print(error.toString()),
+    stompConnectHeaders: {'Authorization': 'Bearer yourToken'},
+    webSocketConnectHeaders: {'Authorization': 'Bearer yourToken'},
+  ),
+);
 
 void main() {
   stompClient.activate();

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1,7 +1,7 @@
 import 'package:stomp_dart_client/stomp_frame.dart';
 
 abstract class Parser {
-  bool escapeHeaders;
+  bool? escapeHeaders;
 
   void parseData(dynamic data);
 

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1,7 +1,7 @@
 import 'package:stomp_dart_client/stomp_frame.dart';
 
 abstract class Parser {
-  bool? escapeHeaders;
+  late bool escapeHeaders;
 
   void parseData(dynamic data);
 

--- a/lib/sock_js/sock_js_parser.dart
+++ b/lib/sock_js/sock_js_parser.dart
@@ -1,19 +1,18 @@
 import 'dart:convert';
 import 'dart:typed_data';
-import 'package:meta/meta.dart';
 import 'package:stomp_dart_client/parser.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:stomp_dart_client/stomp_parser.dart';
 
 class SockJSParser implements Parser {
-  StompParser _stompParser;
+  late StompParser _stompParser;
 
   final Function onDone;
 
   SockJSParser(
-      {@required Function(StompFrame) onStompFrame,
-      Function onPingFrame,
-      @required this.onDone}) {
+      {required Function(StompFrame) onStompFrame,
+      Function? onPingFrame,
+      required this.onDone}) {
     _stompParser = StompParser(onStompFrame, onPingFrame);
   }
 
@@ -32,7 +31,7 @@ class SockJSParser implements Parser {
   }
 
   void _collectData(Uint8List byteList) {
-    if (byteList == null || byteList.isEmpty) {
+    if (byteList.isEmpty) {
       return;
     }
 
@@ -72,15 +71,13 @@ class SockJSParser implements Parser {
         _stompParser.parseData(payload);
         break;
       case 'c': //Close frame
-        if (onDone != null) {
-          onDone();
-        }
+        onDone();
         break;
     }
   }
 
   @override
-  bool escapeHeaders = false;
+  bool? escapeHeaders = false;
 
   @override
   dynamic serializeFrame(StompFrame frame) {

--- a/lib/sock_js/sock_js_parser.dart
+++ b/lib/sock_js/sock_js_parser.dart
@@ -1,20 +1,22 @@
 import 'dart:convert';
 import 'dart:typed_data';
+
 import 'package:stomp_dart_client/parser.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:stomp_dart_client/stomp_parser.dart';
 
 class SockJSParser implements Parser {
+  SockJSParser({
+    required Function(StompFrame) onStompFrame,
+    Function? onPingFrame,
+    required this.onDone,
+  }) {
+    _stompParser = StompParser(onStompFrame, onPingFrame);
+  }
+
   late StompParser _stompParser;
 
   final Function onDone;
-
-  SockJSParser(
-      {required Function(StompFrame) onStompFrame,
-      Function? onPingFrame,
-      required this.onDone}) {
-    _stompParser = StompParser(onStompFrame, onPingFrame);
-  }
 
   @override
   void parseData(dynamic data) {

--- a/lib/sock_js/sock_js_parser.dart
+++ b/lib/sock_js/sock_js_parser.dart
@@ -16,7 +16,7 @@ class SockJSParser implements Parser {
 
   late StompParser _stompParser;
 
-  final Function onDone;
+  final void Function() onDone;
 
   @override
   void parseData(dynamic data) {

--- a/lib/sock_js/sock_js_parser.dart
+++ b/lib/sock_js/sock_js_parser.dart
@@ -8,8 +8,8 @@ import 'package:stomp_dart_client/stomp_parser.dart';
 class SockJSParser implements Parser {
   SockJSParser({
     required Function(StompFrame) onStompFrame,
-    Function? onPingFrame,
     required this.onDone,
+    StompPingFrameCallback? onPingFrame,
   }) {
     _stompParser = StompParser(onStompFrame, onPingFrame);
   }
@@ -79,7 +79,7 @@ class SockJSParser implements Parser {
   }
 
   @override
-  bool? escapeHeaders = false;
+  bool escapeHeaders = false;
 
   @override
   dynamic serializeFrame(StompFrame frame) {

--- a/lib/sock_js/sock_js_utils.dart
+++ b/lib/sock_js/sock_js_utils.dart
@@ -13,9 +13,7 @@ class SockJsUtils {
     var uri = Uri.parse(url);
 
     var pathSegments = <String>[];
-    if (uri.pathSegments != null) {
-      pathSegments.addAll(uri.pathSegments);
-    }
+    pathSegments.addAll(uri.pathSegments);
     pathSegments.add(_generateServerId());
     pathSegments.add(_generateSessionId());
     pathSegments.add('websocket');

--- a/lib/src/_connect_html.dart
+++ b/lib/src/_connect_html.dart
@@ -9,7 +9,7 @@ Future<WebSocketChannel> connect(StompConfig config) async {
   var websocket = WebSocket(config.url)..binaryType = BinaryType.list.value;
   Future onOpenEvent = websocket.onOpen.first;
   if (config.connectionTimeout != null) {
-    onOpenEvent = onOpenEvent.timeout(config.connectionTimeout);
+    onOpenEvent = onOpenEvent.timeout(config.connectionTimeout!);
   }
   await onOpenEvent;
   return HtmlWebSocketChannel(websocket);

--- a/lib/src/_connect_html.dart
+++ b/lib/src/_connect_html.dart
@@ -7,7 +7,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 Future<WebSocketChannel> connect(StompConfig config) async {
   final webSocket = WebSocket(config.url)..binaryType = BinaryType.list.value;
-  Future onOpenEvent = webSocket.onOpen.first;
+  var onOpenEvent = webSocket.onOpen.first;
   if (config.connectionTimeout.inMilliseconds > 0) {
     onOpenEvent = onOpenEvent.timeout(config.connectionTimeout);
   }

--- a/lib/src/_connect_html.dart
+++ b/lib/src/_connect_html.dart
@@ -6,11 +6,11 @@ import 'package:web_socket_channel/html.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 Future<WebSocketChannel> connect(StompConfig config) async {
-  var websocket = WebSocket(config.url)..binaryType = BinaryType.list.value;
-  Future onOpenEvent = websocket.onOpen.first;
+  final webSocket = WebSocket(config.url)..binaryType = BinaryType.list.value;
+  Future onOpenEvent = webSocket.onOpen.first;
   if (config.connectionTimeout.inMilliseconds > 0) {
     onOpenEvent = onOpenEvent.timeout(config.connectionTimeout);
   }
   await onOpenEvent;
-  return HtmlWebSocketChannel(websocket);
+  return HtmlWebSocketChannel(webSocket);
 }

--- a/lib/src/_connect_html.dart
+++ b/lib/src/_connect_html.dart
@@ -8,8 +8,8 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 Future<WebSocketChannel> connect(StompConfig config) async {
   var websocket = WebSocket(config.url)..binaryType = BinaryType.list.value;
   Future onOpenEvent = websocket.onOpen.first;
-  if (config.connectionTimeout != null) {
-    onOpenEvent = onOpenEvent.timeout(config.connectionTimeout!);
+  if (config.connectionTimeout.inMilliseconds > 0) {
+    onOpenEvent = onOpenEvent.timeout(config.connectionTimeout);
   }
   await onOpenEvent;
   return HtmlWebSocketChannel(websocket);

--- a/lib/src/_connect_io.dart
+++ b/lib/src/_connect_io.dart
@@ -10,7 +10,7 @@ Future<WebSocketChannel> connect(StompConfig config) async {
     var websocket =
         WebSocket.connect(config.url, headers: config.webSocketConnectHeaders);
     if (config.connectionTimeout != null) {
-      websocket = websocket.timeout(config.connectionTimeout);
+      websocket = websocket.timeout(config.connectionTimeout!);
     }
     final webSocket = await websocket;
     return IOWebSocketChannel(webSocket);

--- a/lib/src/_connect_io.dart
+++ b/lib/src/_connect_io.dart
@@ -9,8 +9,8 @@ Future<WebSocketChannel> connect(StompConfig config) async {
   try {
     var websocket =
         WebSocket.connect(config.url, headers: config.webSocketConnectHeaders);
-    if (config.connectionTimeout != null) {
-      websocket = websocket.timeout(config.connectionTimeout!);
+    if (config.connectionTimeout.inMilliseconds > 0) {
+      websocket = websocket.timeout(config.connectionTimeout);
     }
     final webSocket = await websocket;
     return IOWebSocketChannel(webSocket);

--- a/lib/src/_connect_io.dart
+++ b/lib/src/_connect_io.dart
@@ -7,13 +7,14 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 Future<WebSocketChannel> connect(StompConfig config) async {
   try {
-    var websocket =
-        WebSocket.connect(config.url, headers: config.webSocketConnectHeaders);
+    var webSocket = WebSocket.connect(
+      config.url,
+      headers: config.webSocketConnectHeaders,
+    );
     if (config.connectionTimeout.inMilliseconds > 0) {
-      websocket = websocket.timeout(config.connectionTimeout);
+      webSocket = webSocket.timeout(config.connectionTimeout);
     }
-    final webSocket = await websocket;
-    return IOWebSocketChannel(webSocket);
+    return IOWebSocketChannel(await webSocket);
   } on SocketException catch (err) {
     throw WebSocketChannelException.from(err);
   }

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:meta/meta.dart';
 import 'package:stomp_dart_client/stomp_config.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:stomp_dart_client/stomp_handler.dart';
@@ -12,15 +11,15 @@ class BadStateException implements Exception {
 }
 
 class StompClient {
-  final StompConfig config;
+  final StompConfig? config;
 
-  StompHandler _handler;
+  StompHandler? _handler;
   bool _isActive = false;
-  Timer _reconnectTimer;
+  Timer? _reconnectTimer;
 
-  StompClient({@required this.config});
+  StompClient({required this.config});
 
-  bool get connected => (_handler != null) && _handler.connected;
+  bool get connected => (_handler != null) && _handler!.connected;
 
   void activate() {
     _isActive = true;
@@ -37,70 +36,70 @@ class StompClient {
 
   void _connect() async {
     if (connected) {
-      config.onDebugMessage('[STOMP] Already connected. Nothing to do!');
+      config!.onDebugMessage('[STOMP] Already connected. Nothing to do!');
       return;
     }
 
-    await config.beforeConnect();
+    await config!.beforeConnect();
 
     if (!_isActive) {
-      config.onDebugMessage('[STOMP] Client was marked as inactive. Skip!');
+      config!.onDebugMessage('[STOMP] Client was marked as inactive. Skip!');
       return;
     }
 
     _handler = StompHandler(
-        config: config.copyWith(onConnect: (_, frame) {
+        config: config!.copyWith(onConnect: (_, frame) {
       if (!_isActive) {
-        config.onDebugMessage(
+        config!.onDebugMessage(
             '[STOMP] Client connected while being deactivated. Will disconnect');
         _handler?.dispose();
         return;
       }
-      config.onConnect(this, frame);
+      config!.onConnect(this, frame);
     }, onWebSocketDone: () {
-      config.onWebSocketDone();
+      config!.onWebSocketDone();
 
       if (_isActive) {
         _scheduleReconnect();
       }
     }));
-    _handler.start();
+    _handler!.start();
   }
 
-  Function({Map<String, String> unsubscribeHeaders}) subscribe(
-      {@required String destination,
-      @required Function(StompFrame) callback,
-      Map<String, String> headers}) {
-    return _handler.subscribe(
+  Function({Map<String, String>? unsubscribeHeaders}) subscribe(
+      {required String destination,
+      required Function(StompFrame) callback,
+      Map<String, String>? headers}) {
+    return _handler!.subscribe(
         destination: destination, callback: callback, headers: headers);
   }
 
   void send(
-      {@required String destination,
-      String body,
-      Uint8List binaryBody,
-      Map<String, String> headers}) {
-    _handler.send(
+      {required String destination,
+      String? body,
+      Uint8List? binaryBody,
+      Map<String, String>? headers}) {
+    _handler!.send(
         destination: destination,
         body: body,
         binaryBody: binaryBody,
         headers: headers);
   }
 
-  void ack({@required String id, Map<String, String> headers}) {
-    _handler.ack(id: id, headers: headers);
+  void ack({required String id, Map<String, String>? headers}) {
+    _handler!.ack(id: id, headers: headers);
   }
 
-  void nack({@required String id, Map<String, String> headers}) {
-    _handler.nack(id: id, headers: headers);
+  void nack({required String id, Map<String, String>? headers}) {
+    _handler!.nack(id: id, headers: headers);
   }
 
   void _scheduleReconnect() {
     _reconnectTimer?.cancel();
 
-    if (config.reconnectDelay > 0) {
+    if (config!.reconnectDelay > 0) {
       _reconnectTimer =
-          Timer(Duration(milliseconds: config.reconnectDelay), () {
+          Timer(Duration(milliseconds: config!.reconnectDelay), () {
         _connect();
       });
     }

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:stomp_dart_client/stomp_config.dart';
-import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:stomp_dart_client/stomp_handler.dart';
 
 class StompClient {
@@ -62,9 +61,9 @@ class StompClient {
     )..start();
   }
 
-  Function({Map<String, String>? unsubscribeHeaders}) subscribe({
+  StompUnsubscribe subscribe({
     required String destination,
-    required Function(StompFrame) callback,
+    required StompFrameCallback callback,
     Map<String, String>? headers,
   }) {
     if (_handler != null) {
@@ -80,16 +79,16 @@ class StompClient {
 
   void send({
     required String destination,
+    Map<String, String>? headers,
     String? body,
     Uint8List? binaryBody,
-    Map<String, String>? headers,
   }) {
     if (_handler != null) {
       _handler!.send(
         destination: destination,
+        headers: headers,
         body: body,
         binaryBody: binaryBody,
-        headers: headers,
       );
     }
   }

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:stomp_dart_client/stomp_config.dart';
+import 'package:stomp_dart_client/stomp_exception.dart';
 import 'package:stomp_dart_client/stomp_handler.dart';
 
 class StompClient {
@@ -66,15 +67,19 @@ class StompClient {
     required StompFrameCallback callback,
     Map<String, String>? headers,
   }) {
-    if (_handler != null) {
-      return _handler!.subscribe(
-        destination: destination,
-        callback: callback,
-        headers: headers,
+    final handler = _handler;
+    if (handler == null) {
+      throw StompBadStateException(
+        'The StompHandler was null. '
+        'Did you forget calling activate() on the client?',
       );
     }
 
-    return ({Map<String, String>? unsubscribeHeaders}) {};
+    return handler.subscribe(
+      destination: destination,
+      callback: callback,
+      headers: headers,
+    );
   }
 
   void send({
@@ -83,26 +88,44 @@ class StompClient {
     String? body,
     Uint8List? binaryBody,
   }) {
-    if (_handler != null) {
-      _handler!.send(
-        destination: destination,
-        headers: headers,
-        body: body,
-        binaryBody: binaryBody,
+    final handler = _handler;
+    if (handler == null) {
+      throw StompBadStateException(
+        'The StompHandler was null. '
+        'Did you forget calling activate() on the client?',
       );
     }
+
+    handler.send(
+      destination: destination,
+      headers: headers,
+      body: body,
+      binaryBody: binaryBody,
+    );
   }
 
   void ack({required String id, Map<String, String>? headers}) {
-    if (_handler != null) {
-      _handler!.ack(id: id, headers: headers);
+    final handler = _handler;
+    if (handler == null) {
+      throw StompBadStateException(
+        'The StompHandler was null. '
+        'Did you forget calling activate() on the client?',
+      );
     }
+
+    handler.ack(id: id, headers: headers);
   }
 
   void nack({required String id, Map<String, String>? headers}) {
-    if (_handler != null) {
-      _handler!.nack(id: id, headers: headers);
+    final handler = _handler;
+    if (handler == null) {
+      throw StompBadStateException(
+        'The StompHandler was null. '
+        'Did you forget calling activate() on the client?',
+      );
     }
+
+    handler.nack(id: id, headers: headers);
   }
 
   void _scheduleReconnect() {

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -24,7 +24,6 @@ class StompClient {
 
   void activate() {
     _isActive = true;
-
     _connect();
   }
 
@@ -49,37 +48,42 @@ class StompClient {
     }
 
     _handler = StompHandler(
-        config: config.copyWith(onConnect: (_, frame) {
-      if (!_isActive) {
-        config.onDebugMessage(
-            '[STOMP] Client connected while being deactivated. Will disconnect');
-        _handler?.dispose();
-        return;
-      }
-      config.onConnect(this, frame);
-    }, onWebSocketDone: () {
-      config.onWebSocketDone();
-
-      if (_isActive) {
-        _scheduleReconnect();
-      }
-    }));
+      config: config.copyWith(
+        onConnect: (_, frame) {
+          if (!_isActive) {
+            config.onDebugMessage(
+                '[STOMP] Client connected while being deactivated. Will disconnect.');
+            _handler?.dispose();
+            return;
+          }
+          config.onConnect(this, frame);
+        },
+        onWebSocketDone: () {
+          config.onWebSocketDone();
+          if (_isActive) {
+            _scheduleReconnect();
+          }
+        },
+      ),
+    );
     _handler!.start();
   }
 
-  Function({Map<String, String>? unsubscribeHeaders}) subscribe(
-      {required String destination,
-      required Function(StompFrame) callback,
-      Map<String, String>? headers}) {
+  Function({Map<String, String>? unsubscribeHeaders}) subscribe({
+    required String destination,
+    required Function(StompFrame) callback,
+    Map<String, String>? headers,
+  }) {
     return _handler!.subscribe(
         destination: destination, callback: callback, headers: headers);
   }
 
-  void send(
-      {required String destination,
-      String? body,
-      Uint8List? binaryBody,
-      Map<String, String>? headers}) {
+  void send({
+    required String destination,
+    String? body,
+    Uint8List? binaryBody,
+    Map<String, String>? headers,
+  }) {
     _handler!.send(
         destination: destination,
         body: body,

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -7,11 +7,12 @@ import 'package:stomp_dart_client/stomp_handler.dart';
 
 class BadStateException implements Exception {
   final String cause;
+
   BadStateException(this.cause);
 }
 
 class StompClient {
-  final StompConfig? config;
+  final StompConfig config;
 
   StompHandler? _handler;
   bool _isActive = false;
@@ -36,28 +37,28 @@ class StompClient {
 
   void _connect() async {
     if (connected) {
-      config!.onDebugMessage('[STOMP] Already connected. Nothing to do!');
+      config.onDebugMessage('[STOMP] Already connected. Nothing to do!');
       return;
     }
 
-    await config!.beforeConnect();
+    await config.beforeConnect();
 
     if (!_isActive) {
-      config!.onDebugMessage('[STOMP] Client was marked as inactive. Skip!');
+      config.onDebugMessage('[STOMP] Client was marked as inactive. Skip!');
       return;
     }
 
     _handler = StompHandler(
-        config: config!.copyWith(onConnect: (_, frame) {
+        config: config.copyWith(onConnect: (_, frame) {
       if (!_isActive) {
-        config!.onDebugMessage(
+        config.onDebugMessage(
             '[STOMP] Client connected while being deactivated. Will disconnect');
         _handler?.dispose();
         return;
       }
-      config!.onConnect(this, frame);
+      config.onConnect(this, frame);
     }, onWebSocketDone: () {
-      config!.onWebSocketDone();
+      config.onWebSocketDone();
 
       if (_isActive) {
         _scheduleReconnect();
@@ -97,9 +98,9 @@ class StompClient {
   void _scheduleReconnect() {
     _reconnectTimer?.cancel();
 
-    if (config!.reconnectDelay > 0) {
+    if (config.reconnectDelay > 0) {
       _reconnectTimer =
-          Timer(Duration(milliseconds: config!.reconnectDelay), () {
+          Timer(Duration(milliseconds: config.reconnectDelay), () {
         _connect();
       });
     }

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -107,9 +107,9 @@ class StompClient {
 
   void _scheduleReconnect() {
     _reconnectTimer?.cancel();
-    if (config.reconnectDelay > 0) {
+    if (config.reconnectDelay.inMilliseconds > 0) {
       _reconnectTimer = Timer(
-        Duration(milliseconds: config.reconnectDelay),
+        config.reconnectDelay,
         () => _connect(),
       );
     }

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -5,12 +5,6 @@ import 'package:stomp_dart_client/stomp_config.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:stomp_dart_client/stomp_handler.dart';
 
-class BadStateException implements Exception {
-  final String cause;
-
-  BadStateException(this.cause);
-}
-
 class StompClient {
   final StompConfig config;
 

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -42,14 +42,14 @@ class StompClient {
 
     _handler = StompHandler(
       config: config.copyWith(
-        onConnect: (_, frame) {
+        onConnect: (frame) {
           if (!_isActive) {
             config.onDebugMessage(
                 '[STOMP] Client connected while being deactivated. Will disconnect.');
             _handler?.dispose();
             return;
           }
-          config.onConnect(this, frame);
+          config.onConnect(frame);
         },
         onWebSocketDone: () {
           config.onWebSocketDone();

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -19,16 +19,17 @@ class StompConfig {
   final bool useSockJS;
 
   /// Time between reconnect attempts
-  /// Set to 0 if you don't want to reconnect automatically
-  final int reconnectDelay;
+  /// Set to a duration with 0 milliseconds if you don't want to reconnect
+  /// automatically
+  final Duration reconnectDelay;
 
   /// Time between outgoing heartbeats
-  /// Set to 0 to not send any heartbeats
-  final int heartbeatOutgoing;
+  /// Set to a duration with 0 milliseconds to not send any heartbeats
+  final Duration heartbeatOutgoing;
 
   /// Time between incoming heartbeats
-  /// Set to 0 to not receive any heartbeats
-  final int heartbeatIncoming;
+  /// Set to a duration with 0 milliseconds to not receive any heartbeats
+  final Duration heartbeatIncoming;
 
   /// Connection timeout. If specified the connection will will be dropped after
   /// the timeout and depending on the [reconnectDelay] it will try again
@@ -73,9 +74,9 @@ class StompConfig {
 
   const StompConfig({
     required this.url,
-    this.reconnectDelay = 5000,
-    this.heartbeatIncoming = 5000,
-    this.heartbeatOutgoing = 5000,
+    this.reconnectDelay = const Duration(seconds: 5),
+    this.heartbeatIncoming = const Duration(seconds: 5),
+    this.heartbeatOutgoing = const Duration(seconds: 5),
     this.connectionTimeout = const Duration(),
     this.stompConnectHeaders = const {},
     this.webSocketConnectHeaders = const {},
@@ -94,9 +95,9 @@ class StompConfig {
 
   StompConfig.SockJS({
     required String url,
-    this.reconnectDelay = 5000,
-    this.heartbeatIncoming = 5000,
-    this.heartbeatOutgoing = 5000,
+    this.reconnectDelay = const Duration(seconds: 5),
+    this.heartbeatIncoming = const Duration(seconds: 5),
+    this.heartbeatOutgoing = const Duration(seconds: 5),
     this.connectionTimeout = const Duration(),
     this.stompConnectHeaders = const {},
     this.webSocketConnectHeaders = const {},
@@ -115,9 +116,9 @@ class StompConfig {
 
   StompConfig copyWith({
     String? url,
-    int? reconnectDelay,
-    int? heartbeatIncoming,
-    int? heartbeatOutgoing,
+    Duration? reconnectDelay,
+    Duration? heartbeatIncoming,
+    Duration? heartbeatOutgoing,
     Duration? connectionTimeout,
     bool? useSockJS,
     Map<String, String>? stompConnectHeaders,

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
 
 import 'package:stomp_dart_client/sock_js/sock_js_utils.dart';
-import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 
 typedef StompFrameCallback = void Function(StompFrame);
 typedef StompBeforeConnectCallback = Future<void> Function();
-typedef StompConnectCallback = void Function(StompClient?, StompFrame);
 typedef StompDebugCallback = void Function(String);
 typedef StompWebSocketErrorCallback = void Function(dynamic);
 typedef StompWebSocketDoneCallback = void Function();
@@ -46,7 +44,7 @@ class StompConfig {
   final StompBeforeConnectCallback beforeConnect;
 
   /// Callback for when STOMP has successfully connected
-  final StompConnectCallback onConnect;
+  final StompFrameCallback onConnect;
 
   /// Callback for when STOMP has disconnected
   final StompFrameCallback onDisconnect;
@@ -124,7 +122,7 @@ class StompConfig {
     Map<String, String>? stompConnectHeaders,
     Map<String, dynamic>? webSocketConnectHeaders,
     StompBeforeConnectCallback? beforeConnect,
-    StompConnectCallback? onConnect,
+    StompFrameCallback? onConnect,
     StompFrameCallback? onStompError,
     StompFrameCallback? onDisconnect,
     StompFrameCallback? onUnhandledFrame,

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -4,6 +4,13 @@ import 'package:stomp_dart_client/sock_js/sock_js_utils.dart';
 import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 
+typedef StompFrameCallback = void Function(StompFrame);
+typedef StompBeforeConnectCallback = Future<void> Function();
+typedef StompConnectCallback = void Function(StompClient?, StompFrame);
+typedef StompDebugCallback = void Function(String);
+typedef StompWebSocketErrorCallback = void Function(dynamic);
+typedef StompWebSocketDoneCallback = void Function();
+
 class StompConfig {
   /// The url of the WebSocket to connect to
   final String url;
@@ -35,34 +42,34 @@ class StompConfig {
 
   /// Asynchronous function to be executed before we connect
   /// the socket
-  final Future<void>? Function() beforeConnect;
+  final StompBeforeConnectCallback beforeConnect;
 
   /// Callback for when STOMP has successfully connected
-  final Function(StompClient?, StompFrame) onConnect;
+  final StompConnectCallback onConnect;
 
   /// Callback for when STOMP has disconnected
-  final Function(StompFrame) onDisconnect;
+  final StompFrameCallback onDisconnect;
 
   /// Callback for any errors encountered with STOMP
-  final Function(StompFrame) onStompError;
+  final StompFrameCallback onStompError;
 
   /// Error callback for unhandled STOMP frames
-  final Function(StompFrame) onUnhandledFrame;
+  final StompFrameCallback onUnhandledFrame;
 
   /// Error callback for unhandled messages inside a frame
-  final Function(StompFrame) onUnhandledMessage;
+  final StompFrameCallback onUnhandledMessage;
 
   /// Error callback for unhandled message receipts
-  final Function(StompFrame) onUnhandledReceipt;
+  final StompFrameCallback onUnhandledReceipt;
 
   /// Error callback for any errors with the underlying WebSocket
-  final Function(dynamic) onWebSocketError;
+  final StompWebSocketErrorCallback onWebSocketError;
 
   /// Callback when the underlying WebSocket connection is done/closed
-  final Function() onWebSocketDone;
+  final StompWebSocketDoneCallback onWebSocketDone;
 
   /// Callback for debug messages
-  final Function(String) onDebugMessage;
+  final StompDebugCallback onDebugMessage;
 
   const StompConfig({
     required this.url,
@@ -115,16 +122,16 @@ class StompConfig {
     bool? useSockJS,
     Map<String, String>? stompConnectHeaders,
     Map<String, dynamic>? webSocketConnectHeaders,
-    Future<void> Function()? beforeConnect,
-    Function(StompClient?, StompFrame)? onConnect,
-    Function(StompFrame)? onStompError,
-    Function(StompFrame)? onDisconnect,
-    Function(StompFrame)? onUnhandledFrame,
-    Function(StompFrame)? onUnhandledMessage,
-    Function(StompFrame)? onUnhandledReceipt,
-    Function(dynamic)? onWebSocketError,
-    Function()? onWebSocketDone,
-    Function(String)? onDebugMessage,
+    StompBeforeConnectCallback? beforeConnect,
+    StompConnectCallback? onConnect,
+    StompFrameCallback? onStompError,
+    StompFrameCallback? onDisconnect,
+    StompFrameCallback? onUnhandledFrame,
+    StompFrameCallback? onUnhandledMessage,
+    StompFrameCallback? onUnhandledReceipt,
+    StompWebSocketErrorCallback? onWebSocketError,
+    StompWebSocketDoneCallback? onWebSocketDone,
+    StompDebugCallback? onDebugMessage,
   }) {
     return StompConfig(
       url: url ?? this.url,
@@ -151,5 +158,5 @@ class StompConfig {
 
   static void _noOp([_, __]) => null;
 
-  static Future<dynamic>? _noOpFuture() => null;
+  static Future<void> _noOpFuture() => Future.value();
 }

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -5,8 +5,10 @@ import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 
 class StompConfig {
+  /// The url of the WebSocket to connect to
   final String url;
 
+  /// Whether to use SockJS
   final bool useSockJS;
 
   /// Time between reconnect attempts
@@ -35,7 +37,7 @@ class StompConfig {
   /// the socket
   final Future<void>? Function() beforeConnect;
 
-  /// Callback for when STOMP has successulfy connected
+  /// Callback for when STOMP has successfully connected
   final Function(StompClient?, StompFrame) onConnect;
 
   /// Callback for when STOMP has disconnected
@@ -53,10 +55,10 @@ class StompConfig {
   /// Error callback for unhandled message receipts
   final Function(StompFrame) onUnhandledReceipt;
 
-  /// Error callback for any errors with the underyling WebSocket
+  /// Error callback for any errors with the underlying WebSocket
   final Function(dynamic) onWebSocketError;
 
-  /// Callback when the underyling WebSocket connection is done/closed
+  /// Callback when the underlying WebSocket connection is done/closed
   final Function() onWebSocketDone;
 
   /// Callback for debug messages

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -35,11 +35,11 @@ class StompConfig {
   /// the timeout and depending on the [reconnectDelay] it will try again
   final Duration connectionTimeout;
 
-  /// Headers to be passed when connecting to STOMP
-  final Map<String, String> stompConnectHeaders;
+  /// Optional Headers to be passed when connecting to STOMP
+  final Map<String, String>? stompConnectHeaders;
 
-  /// Headers to be passed when connecting to WebSocket
-  final Map<String, dynamic> webSocketConnectHeaders;
+  /// Optional Headers to be passed when connecting to WebSocket
+  final Map<String, dynamic>? webSocketConnectHeaders;
 
   /// Asynchronous function to be executed before we connect
   /// the socket
@@ -78,8 +78,8 @@ class StompConfig {
     this.heartbeatIncoming = const Duration(seconds: 5),
     this.heartbeatOutgoing = const Duration(seconds: 5),
     this.connectionTimeout = const Duration(),
-    this.stompConnectHeaders = const {},
-    this.webSocketConnectHeaders = const {},
+    this.stompConnectHeaders,
+    this.webSocketConnectHeaders,
     this.beforeConnect = _noOpFuture,
     this.onConnect = _noOp,
     this.onStompError = _noOp,
@@ -99,8 +99,8 @@ class StompConfig {
     this.heartbeatIncoming = const Duration(seconds: 5),
     this.heartbeatOutgoing = const Duration(seconds: 5),
     this.connectionTimeout = const Duration(),
-    this.stompConnectHeaders = const {},
-    this.webSocketConnectHeaders = const {},
+    this.stompConnectHeaders,
+    this.webSocketConnectHeaders,
     this.beforeConnect = _noOpFuture,
     this.onConnect = _noOp,
     this.onStompError = _noOp,

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -62,25 +62,26 @@ class StompConfig {
   /// Callback for debug messages
   final Function(String) onDebugMessage;
 
-  const StompConfig(
-      {required this.url,
-      this.reconnectDelay = 5000,
-      this.heartbeatIncoming = 5000,
-      this.heartbeatOutgoing = 5000,
-      this.connectionTimeout,
-      this.stompConnectHeaders,
-      this.webSocketConnectHeaders,
-      this.beforeConnect = _noOpFuture,
-      this.onConnect = _noOp,
-      this.onStompError = _noOp,
-      this.onDisconnect = _noOp,
-      this.onUnhandledFrame = _noOp,
-      this.onUnhandledMessage = _noOp,
-      this.onUnhandledReceipt = _noOp,
-      this.onWebSocketError = _noOp,
-      this.onWebSocketDone = _noOp,
-      this.onDebugMessage = _noOp,
-      this.useSockJS = false});
+  const StompConfig({
+    required this.url,
+    this.reconnectDelay = 5000,
+    this.heartbeatIncoming = 5000,
+    this.heartbeatOutgoing = 5000,
+    this.connectionTimeout,
+    this.stompConnectHeaders,
+    this.webSocketConnectHeaders,
+    this.beforeConnect = _noOpFuture,
+    this.onConnect = _noOp,
+    this.onStompError = _noOp,
+    this.onDisconnect = _noOp,
+    this.onUnhandledFrame = _noOp,
+    this.onUnhandledMessage = _noOp,
+    this.onUnhandledReceipt = _noOp,
+    this.onWebSocketError = _noOp,
+    this.onWebSocketDone = _noOp,
+    this.onDebugMessage = _noOp,
+    this.useSockJS = false,
+  });
 
   StompConfig.SockJS({
     required String url,
@@ -103,46 +104,50 @@ class StompConfig {
   })  : useSockJS = true,
         url = SockJsUtils().generateTransportUrl(url);
 
-  StompConfig copyWith(
-          {String? url,
-          int? reconnectDelay,
-          int? heartbeatIncoming,
-          int? heartbeatOutgoing,
-          Duration? connectionTimeout,
-          bool? useSockJS,
-          Map<String, String>? stompConnectHeaders,
-          Map<String, dynamic>? webSocketConnectHeaders,
-          Future<void> Function()? beforeConnect,
-          Function(StompClient?, StompFrame)? onConnect,
-          Function(StompFrame)? onStompError,
-          Function(StompFrame)? onDisconnect,
-          Function(StompFrame)? onUnhandledFrame,
-          Function(StompFrame)? onUnhandledMessage,
-          Function(StompFrame)? onUnhandledReceipt,
-          Function(dynamic)? onWebSocketError,
-          Function()? onWebSocketDone,
-          Function(String)? onDebugMessage}) =>
-      StompConfig(
-          url: url ?? this.url,
-          reconnectDelay: reconnectDelay ?? this.reconnectDelay,
-          heartbeatIncoming: heartbeatIncoming ?? this.heartbeatIncoming,
-          heartbeatOutgoing: heartbeatOutgoing ?? this.heartbeatOutgoing,
-          connectionTimeout: connectionTimeout ?? this.connectionTimeout,
-          useSockJS: useSockJS ?? this.useSockJS,
-          webSocketConnectHeaders:
-              webSocketConnectHeaders ?? this.webSocketConnectHeaders,
-          stompConnectHeaders: stompConnectHeaders ?? this.stompConnectHeaders,
-          beforeConnect: beforeConnect ?? this.beforeConnect,
-          onConnect: onConnect ?? this.onConnect,
-          onStompError: onStompError ?? this.onStompError,
-          onDisconnect: onDisconnect ?? this.onDisconnect,
-          onUnhandledFrame: onUnhandledFrame ?? this.onUnhandledFrame,
-          onUnhandledMessage: onUnhandledMessage ?? this.onUnhandledMessage,
-          onUnhandledReceipt: onUnhandledReceipt ?? this.onUnhandledReceipt,
-          onWebSocketError: onWebSocketError ?? this.onWebSocketError,
-          onWebSocketDone: onWebSocketDone ?? this.onWebSocketDone,
-          onDebugMessage: onDebugMessage ?? this.onDebugMessage);
+  StompConfig copyWith({
+    String? url,
+    int? reconnectDelay,
+    int? heartbeatIncoming,
+    int? heartbeatOutgoing,
+    Duration? connectionTimeout,
+    bool? useSockJS,
+    Map<String, String>? stompConnectHeaders,
+    Map<String, dynamic>? webSocketConnectHeaders,
+    Future<void> Function()? beforeConnect,
+    Function(StompClient?, StompFrame)? onConnect,
+    Function(StompFrame)? onStompError,
+    Function(StompFrame)? onDisconnect,
+    Function(StompFrame)? onUnhandledFrame,
+    Function(StompFrame)? onUnhandledMessage,
+    Function(StompFrame)? onUnhandledReceipt,
+    Function(dynamic)? onWebSocketError,
+    Function()? onWebSocketDone,
+    Function(String)? onDebugMessage,
+  }) {
+    return StompConfig(
+      url: url ?? this.url,
+      reconnectDelay: reconnectDelay ?? this.reconnectDelay,
+      heartbeatIncoming: heartbeatIncoming ?? this.heartbeatIncoming,
+      heartbeatOutgoing: heartbeatOutgoing ?? this.heartbeatOutgoing,
+      connectionTimeout: connectionTimeout ?? this.connectionTimeout,
+      useSockJS: useSockJS ?? this.useSockJS,
+      webSocketConnectHeaders:
+          webSocketConnectHeaders ?? this.webSocketConnectHeaders,
+      stompConnectHeaders: stompConnectHeaders ?? this.stompConnectHeaders,
+      beforeConnect: beforeConnect ?? this.beforeConnect,
+      onConnect: onConnect ?? this.onConnect,
+      onStompError: onStompError ?? this.onStompError,
+      onDisconnect: onDisconnect ?? this.onDisconnect,
+      onUnhandledFrame: onUnhandledFrame ?? this.onUnhandledFrame,
+      onUnhandledMessage: onUnhandledMessage ?? this.onUnhandledMessage,
+      onUnhandledReceipt: onUnhandledReceipt ?? this.onUnhandledReceipt,
+      onWebSocketError: onWebSocketError ?? this.onWebSocketError,
+      onWebSocketDone: onWebSocketDone ?? this.onWebSocketDone,
+      onDebugMessage: onDebugMessage ?? this.onDebugMessage,
+    );
+  }
 
   static void _noOp([_, __]) => null;
+
   static Future<dynamic>? _noOpFuture() => null;
 }

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -25,13 +25,13 @@ class StompConfig {
 
   /// Connection timeout. If specified the connection will will be dropped after
   /// the timeout and depending on the [reconnectDelay] it will try again
-  final Duration? connectionTimeout;
+  final Duration connectionTimeout;
 
   /// Headers to be passed when connecting to STOMP
-  final Map<String, String>? stompConnectHeaders;
+  final Map<String, String> stompConnectHeaders;
 
   /// Headers to be passed when connecting to WebSocket
-  final Map<String, dynamic>? webSocketConnectHeaders;
+  final Map<String, dynamic> webSocketConnectHeaders;
 
   /// Asynchronous function to be executed before we connect
   /// the socket
@@ -69,9 +69,9 @@ class StompConfig {
     this.reconnectDelay = 5000,
     this.heartbeatIncoming = 5000,
     this.heartbeatOutgoing = 5000,
-    this.connectionTimeout,
-    this.stompConnectHeaders,
-    this.webSocketConnectHeaders,
+    this.connectionTimeout = const Duration(),
+    this.stompConnectHeaders = const {},
+    this.webSocketConnectHeaders = const {},
     this.beforeConnect = _noOpFuture,
     this.onConnect = _noOp,
     this.onStompError = _noOp,
@@ -90,9 +90,9 @@ class StompConfig {
     this.reconnectDelay = 5000,
     this.heartbeatIncoming = 5000,
     this.heartbeatOutgoing = 5000,
-    this.connectionTimeout,
-    this.stompConnectHeaders,
-    this.webSocketConnectHeaders,
+    this.connectionTimeout = const Duration(),
+    this.stompConnectHeaders = const {},
+    this.webSocketConnectHeaders = const {},
     this.beforeConnect = _noOpFuture,
     this.onConnect = _noOp,
     this.onStompError = _noOp,

--- a/lib/stomp_config.dart
+++ b/lib/stomp_config.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
 import 'package:stomp_dart_client/sock_js/sock_js_utils.dart';
 import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
@@ -24,20 +23,20 @@ class StompConfig {
 
   /// Connection timeout. If specified the connection will will be dropped after
   /// the timeout and depending on the [reconnectDelay] it will try again
-  final Duration connectionTimeout;
+  final Duration? connectionTimeout;
 
   /// Headers to be passed when connecting to STOMP
-  final Map<String, String> stompConnectHeaders;
+  final Map<String, String>? stompConnectHeaders;
 
   /// Headers to be passed when connecting to WebSocket
-  final Map<String, dynamic> webSocketConnectHeaders;
+  final Map<String, dynamic>? webSocketConnectHeaders;
 
   /// Asynchronous function to be executed before we connect
   /// the socket
-  final Future<void> Function() beforeConnect;
+  final Future<void>? Function() beforeConnect;
 
   /// Callback for when STOMP has successulfy connected
-  final Function(StompClient, StompFrame) onConnect;
+  final Function(StompClient?, StompFrame) onConnect;
 
   /// Callback for when STOMP has disconnected
   final Function(StompFrame) onDisconnect;
@@ -64,7 +63,7 @@ class StompConfig {
   final Function(String) onDebugMessage;
 
   const StompConfig(
-      {@required this.url,
+      {required this.url,
       this.reconnectDelay = 5000,
       this.heartbeatIncoming = 5000,
       this.heartbeatOutgoing = 5000,
@@ -84,7 +83,7 @@ class StompConfig {
       this.useSockJS = false});
 
   StompConfig.SockJS({
-    @required String url,
+    required String url,
     this.reconnectDelay = 5000,
     this.heartbeatIncoming = 5000,
     this.heartbeatOutgoing = 5000,
@@ -105,24 +104,24 @@ class StompConfig {
         url = SockJsUtils().generateTransportUrl(url);
 
   StompConfig copyWith(
-          {String url,
-          int reconnectDelay,
-          int heartbeatIncoming,
-          int heartbeatOutgoing,
-          Duration connectionTimeout,
-          bool useSockJS,
-          Map<String, String> stompConnectHeaders,
-          Map<String, dynamic> webSocketConnectHeaders,
-          Future<void> Function() beforeConnect,
-          Function(StompClient, StompFrame) onConnect,
-          Function(StompFrame) onStompError,
-          Function(StompFrame) onDisconnect,
-          Function(StompFrame) onUnhandledFrame,
-          Function(StompFrame) onUnhandledMessage,
-          Function(StompFrame) onUnhandledReceipt,
-          Function(dynamic) onWebSocketError,
-          Function() onWebSocketDone,
-          Function(String) onDebugMessage}) =>
+          {String? url,
+          int? reconnectDelay,
+          int? heartbeatIncoming,
+          int? heartbeatOutgoing,
+          Duration? connectionTimeout,
+          bool? useSockJS,
+          Map<String, String>? stompConnectHeaders,
+          Map<String, dynamic>? webSocketConnectHeaders,
+          Future<void> Function()? beforeConnect,
+          Function(StompClient?, StompFrame)? onConnect,
+          Function(StompFrame)? onStompError,
+          Function(StompFrame)? onDisconnect,
+          Function(StompFrame)? onUnhandledFrame,
+          Function(StompFrame)? onUnhandledMessage,
+          Function(StompFrame)? onUnhandledReceipt,
+          Function(dynamic)? onWebSocketError,
+          Function()? onWebSocketDone,
+          Function(String)? onDebugMessage}) =>
       StompConfig(
           url: url ?? this.url,
           reconnectDelay: reconnectDelay ?? this.reconnectDelay,
@@ -145,5 +144,5 @@ class StompConfig {
           onDebugMessage: onDebugMessage ?? this.onDebugMessage);
 
   static void _noOp([_, __]) => null;
-  static Future<dynamic> _noOpFuture() => null;
+  static Future<dynamic>? _noOpFuture() => null;
 }

--- a/lib/stomp_exception.dart
+++ b/lib/stomp_exception.dart
@@ -1,0 +1,7 @@
+class StompBadStateException implements Exception {
+  StompBadStateException([
+    String? message,
+  ]) : message = message ?? '';
+
+  String message;
+}

--- a/lib/stomp_exception.dart
+++ b/lib/stomp_exception.dart
@@ -1,7 +1,12 @@
 class StompBadStateException implements Exception {
-  StompBadStateException([
-    String? message,
-  ]) : message = message ?? '';
+  StompBadStateException([this.message]);
 
-  String message;
+  String? message;
+
+  @override
+  String toString() {
+    Object? message = this.message;
+    if (message == null) return 'StompBadStateException';
+    return 'StompBadStateException: $message';
+  }
 }

--- a/lib/stomp_frame.dart
+++ b/lib/stomp_frame.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+typedef StompPingFrameCallback = void Function();
+
 class StompFrame {
   final String command;
   final Map<String, String> headers;

--- a/lib/stomp_frame.dart
+++ b/lib/stomp_frame.dart
@@ -1,13 +1,15 @@
 import 'dart:typed_data';
 
-import 'package:meta/meta.dart';
-
 class StompFrame {
   final String command;
   final Map<String, String> headers;
-  final String body;
-  final Uint8List binaryBody;
+  final String? body;
+  final Uint8List? binaryBody;
 
-  StompFrame(
-      {@required this.command, this.headers, this.body, this.binaryBody});
+  StompFrame({
+    required this.command,
+    this.headers = const {},
+    this.body,
+    this.binaryBody,
+  });
 }

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -140,7 +140,7 @@ class StompHandler {
 
   void _connectToStomp() {
     final connectHeaders = {
-      ...config.stompConnectHeaders,
+      ...?config.stompConnectHeaders,
       'accept-version': ['1.0', '1.1', '1.2'].join(','),
       'heart-beat': [
         config.heartbeatOutgoing,

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -236,7 +236,7 @@ class StompHandler {
       _setupHeartbeat(frame);
     }
 
-    config.onConnect(null, frame);
+    config.onConnect(frame);
   }
 
   void _onMessageFrame(StompFrame frame) {

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -54,14 +54,14 @@ class StompHandler {
       channel!.stream.listen(_onData, onError: _onError, onDone: _onDone);
       _connectToStomp();
     } on WebSocketChannelException catch (err) {
-      if (config.reconnectDelay == 0) {
+      if (config.reconnectDelay.inMilliseconds == 0) {
         _onError(err);
       } else {
         config.onDebugMessage('Connection error...reconnecting');
         _onDone();
       }
     } on TimeoutException catch (err) {
-      if (config.reconnectDelay == 0) {
+      if (config.reconnectDelay.inMilliseconds == 0) {
         _onError(err);
       } else {
         config.onDebugMessage('Connection timed out...reconnecting');
@@ -271,8 +271,8 @@ class StompHandler {
     final serverHeartbeats = frame.headers['heart-beat']!.split(',');
     final serverOutgoing = int.parse(serverHeartbeats[0]);
     final serverIncoming = int.parse(serverHeartbeats[1]);
-    if (config.heartbeatOutgoing > 0 && serverIncoming > 0) {
-      final ttl = max(config.heartbeatOutgoing, serverIncoming);
+    if (config.heartbeatOutgoing.inMilliseconds > 0 && serverIncoming > 0) {
+      final ttl = max(config.heartbeatOutgoing.inMilliseconds, serverIncoming);
       _heartbeatSender?.cancel();
       _heartbeatSender = Timer.periodic(Duration(milliseconds: ttl), (_) {
         if (channel != null) {
@@ -286,8 +286,8 @@ class StompHandler {
       });
     }
 
-    if (config.heartbeatIncoming > 0 && serverOutgoing > 0) {
-      final ttl = max(config.heartbeatIncoming, serverOutgoing);
+    if (config.heartbeatIncoming.inMilliseconds > 0 && serverOutgoing > 0) {
+      final ttl = max(config.heartbeatIncoming.inMilliseconds, serverOutgoing);
       _heartbeatReceiver?.cancel();
       _heartbeatReceiver = Timer.periodic(Duration(milliseconds: ttl), (_) {
         final deltaMs = DateTime.now().millisecondsSinceEpoch -

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -132,7 +132,7 @@ class StompHandler {
   }
 
   void _connectToStomp() {
-    var connectHeaders = config.stompConnectHeaders ?? {};
+    final connectHeaders = {...config.stompConnectHeaders};
     connectHeaders['accept-version'] = ['1.0', '1.1', '1.2'].join(',');
     connectHeaders['heart-beat'] =
         [config.heartbeatOutgoing, config.heartbeatIncoming].join(',');

--- a/lib/stomp_handler.dart
+++ b/lib/stomp_handler.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:stomp_dart_client/parser.dart';
 import 'package:stomp_dart_client/sock_js/sock_js_parser.dart';
 import 'package:stomp_dart_client/stomp_config.dart';
+import 'package:stomp_dart_client/stomp_exception.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:stomp_dart_client/stomp_parser.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -177,10 +178,16 @@ class StompHandler {
       binaryBody: binaryBody,
     );
 
-    if (channel != null) {
-      dynamic serializedFrame = _parser.serializeFrame(frame);
-      config.onDebugMessage('>>> ' + serializedFrame.toString());
+    dynamic serializedFrame = _parser.serializeFrame(frame);
+    config.onDebugMessage('>>> ' + serializedFrame.toString());
+
+    try {
       channel!.sink.add(serializedFrame);
+    } catch (_) {
+      throw StompBadStateException(
+        'The StompHandler has no active connection '
+        'or the connection was unexpectedly closed.',
+      );
     }
   }
 

--- a/lib/stomp_parser.dart
+++ b/lib/stomp_parser.dart
@@ -229,10 +229,10 @@ class StompParser implements Parser {
         .replaceAll(RegExp(r'\r'), '\\r');
   }
 
-  Map<String, String> _escapeHeaders(Map<String?, String> headers) {
+  Map<String, String> _escapeHeaders(Map<String, String> headers) {
     final escapedHeaders = <String, String>{};
     headers.forEach((key, value) {
-      escapedHeaders[_escapeString(key!)] = _escapeString(value);
+      escapedHeaders[_escapeString(key)] = _escapeString(value);
     });
     return escapedHeaders;
   }

--- a/lib/stomp_parser.dart
+++ b/lib/stomp_parser.dart
@@ -10,26 +10,26 @@ import 'package:stomp_dart_client/stomp_frame.dart';
 /// Credit: https://github.com/kum-deepak
 ///
 class StompParser implements Parser {
-  String _resultCommand;
-  Map<String, String> _resultHeaders;
-  String _resultBody;
+  String? _resultCommand;
+  Map<String, String>? _resultHeaders;
+  String? _resultBody;
 
-  List<int> _currentToken;
-  String _currentHeaderKey;
-  int _bodyBytesRemaining;
+  late List<int> _currentToken;
+  String? _currentHeaderKey;
+  int _bodyBytesRemaining = 0;
 
-  final Function(StompFrame) onStompFrame;
-  final Function onPingFrame;
+  final Function(StompFrame)? onStompFrame;
+  final Function? onPingFrame;
 
   final NULL = 0;
   final LF = 10;
   final CR = 13;
   final COLON = 58;
 
-  Function(int) _parseByte;
+  late Function(int) _parseByte;
 
   @override
-  bool escapeHeaders = false;
+  bool? escapeHeaders = false;
 
   StompParser(this.onStompFrame, [this.onPingFrame]) {
     _initState();
@@ -63,7 +63,7 @@ class StompParser implements Parser {
     }
     if (byte == LF) {
       // Incoming Ping
-      onPingFrame != null ? onPingFrame() : null;
+      onPingFrame != null ? onPingFrame!() : null;
       return;
     }
 
@@ -115,7 +115,7 @@ class StompParser implements Parser {
       return;
     }
     if (byte == LF) {
-      _resultHeaders[_currentHeaderKey] = _consumeTokenAsString();
+      _resultHeaders![_currentHeaderKey!] = _consumeTokenAsString();
       _currentHeaderKey = null;
       _parseByte = _collectHeaders;
       return;
@@ -143,13 +143,14 @@ class StompParser implements Parser {
   }
 
   void _setupCollectBody() {
-    if (_resultHeaders.containsKey('content-length')) {
-      _bodyBytesRemaining = int.tryParse(_resultHeaders['content-length']);
-      if (_bodyBytesRemaining == null) {
+    if (_resultHeaders!.containsKey('content-length')) {
+      final remaining = int.tryParse(_resultHeaders!['content-length']!);
+      if (remaining == null) {
         print(
             '[STOMP] Unable to parse content-length although it was present. Using fallback');
         _parseByte = _collectTerminatedBody;
       } else {
+        _bodyBytesRemaining = remaining;
         _parseByte = _collectFixedSizeBody;
       }
     } else {
@@ -160,13 +161,15 @@ class StompParser implements Parser {
   void _consumeBody() {
     _resultBody = _consumeTokenAsString();
 
-    if (escapeHeaders) {
+    if (escapeHeaders!) {
       _unescapeResultHeaders();
     }
 
     try {
-      onStompFrame(StompFrame(
-          command: _resultCommand, headers: _resultHeaders, body: _resultBody));
+      onStompFrame!(StompFrame(
+          command: _resultCommand!,
+          headers: _resultHeaders!,
+          body: _resultBody));
     } finally {
       _initState();
     }
@@ -189,7 +192,7 @@ class StompParser implements Parser {
   /// https://stomp.github.io/stomp-specification-1.2.html#Value_Encoding
   void _unescapeResultHeaders() {
     final unescapedHeaders = <String, String>{};
-    _resultHeaders.forEach((key, value) {
+    _resultHeaders!.forEach((key, value) {
       unescapedHeaders[_unescapeString(key)] = _unescapeString(value);
     });
     _resultHeaders = unescapedHeaders;
@@ -213,10 +216,10 @@ class StompParser implements Parser {
         .replaceAll(RegExp(r'\r'), '\\r');
   }
 
-  Map<String, String> _escapeHeaders(Map<String, String> headers) {
+  Map<String, String> _escapeHeaders(Map<String?, String> headers) {
     final escapedHeaders = <String, String>{};
-    headers?.forEach((key, value) {
-      escapedHeaders[_escapeString(key)] = _escapeString(value);
+    headers.forEach((key, value) {
+      escapedHeaders[_escapeString(key!)] = _escapeString(value);
     });
     return escapedHeaders;
   }
@@ -231,15 +234,15 @@ class StompParser implements Parser {
 
     if (frame.binaryBody != null) {
       final binaryList = Uint8List(
-          serializedHeaders.codeUnits.length + 1 + frame.binaryBody.length);
+          serializedHeaders.codeUnits.length + 1 + frame.binaryBody!.length);
       binaryList.setRange(
           0, serializedHeaders.codeUnits.length, serializedHeaders.codeUnits);
       binaryList.setRange(
           serializedHeaders.codeUnits.length,
-          serializedHeaders.codeUnits.length + frame.binaryBody.length,
-          frame.binaryBody);
-      binaryList[serializedHeaders.codeUnits.length + frame.binaryBody.length] =
-          NULL;
+          serializedHeaders.codeUnits.length + frame.binaryBody!.length,
+          frame.binaryBody!);
+      binaryList[
+          serializedHeaders.codeUnits.length + frame.binaryBody!.length] = NULL;
       return binaryList;
     } else {
       var serializedFrame = serializedHeaders;
@@ -249,19 +252,19 @@ class StompParser implements Parser {
     }
   }
 
-  String _serializeCmdAndHeaders(StompFrame frame) {
+  String? _serializeCmdAndHeaders(StompFrame frame) {
     var serializedFrame = frame.command;
-    var headers = frame.headers ?? {};
+    var headers = frame.headers;
     var bodyLength = 0;
     if (frame.binaryBody != null) {
-      bodyLength = frame.binaryBody.length;
+      bodyLength = frame.binaryBody!.length;
     } else if (frame.body != null) {
-      bodyLength = utf8.encode(frame.body).length;
+      bodyLength = utf8.encode(frame.body!).length;
     }
     if (bodyLength > 0) {
       headers['content-length'] = bodyLength.toString();
     }
-    if (escapeHeaders) {
+    if (escapeHeaders!) {
       headers = _escapeHeaders(headers);
     }
     headers.forEach((key, value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,13 +3,12 @@ homepage: https://github.com/blackhorse-one/stomp_dart
 version: 0.3.8
 description: Dart STOMP client for easy messaging interoperability. Build with flutter in mind, but should work for every dart application.
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  meta: ^1.1.7
-  web_socket_channel: ^1.1.0
+  web_socket_channel: ^2.0.0
 
 dev_dependencies:
-  test: ^1.9.2
-  pedantic: ^1.0.0
-  stream_channel: ^2.0.0
+  test: ^1.16.5
+  pedantic: ^1.11.0
+  stream_channel: ^2.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stomp_dart_client
 homepage: https://github.com/blackhorse-one/stomp_dart
-version: 0.3.8
+version: 0.4.0
 description: Dart STOMP client for easy messaging interoperability. Build with flutter in mind, but should work for every dart application.
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/test/sock_js_parser_test.dart
+++ b/test/sock_js_parser_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:stomp_dart_client/sock_js/sock_js_parser.dart';
+import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -9,7 +10,7 @@ void main() {
       final stompMsg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
       final sockjsMsg = 'm${json.encode(stompMsg)}';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 2);
         expect(frame.headers.containsKey('destination'), isTrue);
@@ -31,7 +32,7 @@ void main() {
       final stompMsg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
       final sockjsMsg = 'a[${json.encode(stompMsg)}]';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 2);
         expect(frame.headers.containsKey('destination'), isTrue);
@@ -56,7 +57,7 @@ void main() {
           'a[${json.encode(stompMsg1)},${json.encode(stompMsg2)}]';
       var count = 0;
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 2);
         expect(frame.headers.containsKey('destination'), isTrue);

--- a/test/sock_js_parser_test.dart
+++ b/test/sock_js_parser_test.dart
@@ -8,138 +8,142 @@ void main() {
   group('SockJSParser', () {
     test('can parse basic message', () {
       final stompMsg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
-      final sockjsMsg = 'm${json.encode(stompMsg)}';
+      final sockJsMsg = 'm${json.encode(stompMsg)}';
 
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 2);
-        expect(frame.headers.containsKey('destination'), isTrue);
-        expect(frame.headers.containsKey('message-id'), isTrue);
-        expect(frame.headers['destination'], 'foo');
-        expect(frame.headers['message-id'], '456');
-        expect(frame.body, isEmpty);
-      }, count: 1);
+      final callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 2);
+          expect(frame.headers.containsKey('destination'), isTrue);
+          expect(frame.headers.containsKey('message-id'), isTrue);
+          expect(frame.headers['destination'], 'foo');
+          expect(frame.headers['message-id'], '456');
+          expect(frame.body, isEmpty);
+        },
+        count: 1,
+      );
 
-      var onDoneCallback = expectAsync1((_) {}, count: 0);
+      final onDoneCallback = expectAsync1((_) {}, count: 0);
 
-      final parser =
-          SockJSParser(onStompFrame: callback, onDone: onDoneCallback);
-
-      parser.parseData(sockjsMsg);
+      SockJSParser(
+        onStompFrame: callback,
+        onDone: onDoneCallback,
+      ).parseData(sockJsMsg);
     });
 
     test('can parse array with 1 message', () {
       final stompMsg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
-      final sockjsMsg = 'a[${json.encode(stompMsg)}]';
+      final sockJsMsg = 'a[${json.encode(stompMsg)}]';
 
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 2);
-        expect(frame.headers.containsKey('destination'), isTrue);
-        expect(frame.headers.containsKey('message-id'), isTrue);
-        expect(frame.headers['destination'], 'foo');
-        expect(frame.headers['message-id'], '456');
-        expect(frame.body, isEmpty);
-      }, count: 1);
+      final callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 2);
+          expect(frame.headers.containsKey('destination'), isTrue);
+          expect(frame.headers.containsKey('message-id'), isTrue);
+          expect(frame.headers['destination'], 'foo');
+          expect(frame.headers['message-id'], '456');
+          expect(frame.body, isEmpty);
+        },
+        count: 1,
+      );
 
-      var onDoneCallback = expectAsync1((_) {}, count: 0);
+      final onDoneCallback = expectAsync1((_) {}, count: 0);
 
-      final parser =
-          SockJSParser(onStompFrame: callback, onDone: onDoneCallback);
-
-      parser.parseData(sockjsMsg);
+      SockJSParser(
+        onStompFrame: callback,
+        onDone: onDoneCallback,
+      ).parseData(sockJsMsg);
     });
 
     test('can parse array with 2 messages', () {
       final stompMsg1 = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
       final stompMsg2 = 'MESSAGE\ndestination:foo\nmessage-id:457\n\n\x00';
-      final sockjsMsg =
+      final sockJsMsg =
           'a[${json.encode(stompMsg1)},${json.encode(stompMsg2)}]';
       var count = 0;
 
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 2);
-        expect(frame.headers.containsKey('destination'), isTrue);
-        expect(frame.headers.containsKey('message-id'), isTrue);
-        expect(frame.headers['destination'], 'foo');
-        expect(frame.headers['message-id'], count == 0 ? '456' : '457');
-        expect(frame.body, isEmpty);
-        ++count;
-      }, count: 2);
+      final callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 2);
+          expect(frame.headers.containsKey('destination'), isTrue);
+          expect(frame.headers.containsKey('message-id'), isTrue);
+          expect(frame.headers['destination'], 'foo');
+          expect(frame.headers['message-id'], count == 0 ? '456' : '457');
+          expect(frame.body, isEmpty);
+          ++count;
+        },
+        count: 2,
+      );
 
       var onDoneCallback = expectAsync1((_) {}, count: 0);
 
-      final parser =
-          SockJSParser(onStompFrame: callback, onDone: onDoneCallback);
-
-      parser.parseData(sockjsMsg);
+      SockJSParser(
+        onStompFrame: callback,
+        onDone: onDoneCallback,
+      ).parseData(sockJsMsg);
     });
 
     test('don\'t parse open frame', () {
-      final sockjsMsg = 'o';
+      final sockJsMsg = 'o';
 
-      var callback = expectAsync1((frame) {}, count: 0);
+      final callback = expectAsync1((frame) {}, count: 0);
+      final onDoneCallback = expectAsync1((_) {}, count: 0);
 
-      var onDoneCallback = expectAsync1((_) {}, count: 0);
-
-      final parser =
-          SockJSParser(onStompFrame: callback, onDone: onDoneCallback);
-
-      parser.parseData(sockjsMsg);
+      SockJSParser(
+        onStompFrame: callback,
+        onDone: onDoneCallback,
+      ).parseData(sockJsMsg);
     });
 
     test('don\'t parse Heartbeat frame', () {
-      final sockjsMsg = 'h';
+      final sockJsMsg = 'h';
 
-      var callback = expectAsync1((frame) {}, count: 0);
+      final callback = expectAsync1((frame) {}, count: 0);
+      final onDoneCallback = expectAsync1((_) {}, count: 0);
 
-      var onDoneCallback = expectAsync1((_) {}, count: 0);
-
-      final parser =
-          SockJSParser(onStompFrame: callback, onDone: onDoneCallback);
-
-      parser.parseData(sockjsMsg);
+      SockJSParser(
+        onStompFrame: callback,
+        onDone: onDoneCallback,
+      ).parseData(sockJsMsg);
     });
 
     test('don\'t parse empty message', () {
-      final sockjsMsg = 'm';
+      final sockJsMsg = 'm';
 
-      var callback = expectAsync1((frame) {}, count: 0);
+      final callback = expectAsync1((frame) {}, count: 0);
+      final onDoneCallback = expectAsync1((_) {}, count: 0);
 
-      var onDoneCallback = expectAsync1((_) {}, count: 0);
-
-      final parser =
-          SockJSParser(onStompFrame: callback, onDone: onDoneCallback);
-
-      parser.parseData(sockjsMsg);
+      SockJSParser(
+        onStompFrame: callback,
+        onDone: onDoneCallback,
+      ).parseData(sockJsMsg);
     });
 
     test('don\'t parse no json message', () {
       final stompMsg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
-      final sockjsMsg = 'm$stompMsg';
+      final sockJsMsg = 'm$stompMsg';
 
-      var callback = expectAsync1((frame) {}, count: 0);
+      final callback = expectAsync1((frame) {}, count: 0);
+      final onDoneCallback = expectAsync1((_) {}, count: 0);
 
-      var onDoneCallback = expectAsync1((_) {}, count: 0);
-
-      final parser =
-          SockJSParser(onStompFrame: callback, onDone: onDoneCallback);
-
-      parser.parseData(sockjsMsg);
+      SockJSParser(
+        onStompFrame: callback,
+        onDone: onDoneCallback,
+      ).parseData(sockJsMsg);
     });
 
     test('close frame message', () {
-      final sockjsMsg = 'c[1007,"null"]';
+      final sockJsMsg = 'c[1007,"null"]';
 
-      var callback = expectAsync1((frame) {}, count: 0);
+      final callback = expectAsync1((frame) {}, count: 0);
+      final onDoneCallback = expectAsync0(() {}, count: 1);
 
-      var onDoneCallback = expectAsync0(() {}, count: 1);
-
-      final parser =
-          SockJSParser(onStompFrame: callback, onDone: onDoneCallback);
-
-      parser.parseData(sockjsMsg);
+      SockJSParser(
+        onStompFrame: callback,
+        onDone: onDoneCallback,
+      ).parseData(sockJsMsg);
     });
   });
 }

--- a/test/sock_js_utils_test.dart
+++ b/test/sock_js_utils_test.dart
@@ -5,7 +5,6 @@ void main() {
   group('SockJsUtils', () {
     test('generate websocket url with http url', () {
       final url = 'http://localhost:5000/test';
-
       final webSocketUrl = SockJsUtils().generateTransportUrl(url);
 
       expect(webSocketUrl, isNotNull);
@@ -15,7 +14,6 @@ void main() {
 
     test('generate websocket url with https url', () {
       final url = 'https://localhost:5000/test';
-
       final webSocketUrl = SockJsUtils().generateTransportUrl(url);
 
       expect(webSocketUrl, isNotNull);
@@ -25,7 +23,6 @@ void main() {
 
     test('generate websocket url with no empty fragment', () {
       final url = 'https://localhost:5000/test';
-
       final webSocketUrl = SockJsUtils().generateTransportUrl(url);
 
       expect(webSocketUrl, isNotNull);
@@ -36,7 +33,10 @@ void main() {
     test('generate websocket url with bad url', () {
       final url = 'wss://localhost:5000/test';
 
-      expect(() => SockJsUtils().generateTransportUrl(url), throwsArgumentError);
+      expect(
+        () => SockJsUtils().generateTransportUrl(url),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/test/stomp_handler_test.dart
+++ b/test/stomp_handler_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:stomp_dart_client/stomp_config.dart';
+import 'package:stomp_dart_client/stomp_exception.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:stomp_dart_client/stomp_handler.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -316,6 +317,26 @@ void main() {
           onDisconnect: onDisconnect,
         ),
       )..start();
+    });
+
+    test('throws when trying to transmit data before start was called', () {
+      final handler = StompHandler(config: StompConfig(url: ''));
+      expect(
+        () => handler.subscribe(destination: '', callback: (_) {}),
+        throwsA(TypeMatcher<StompBadStateException>()),
+      );
+      expect(
+        () => handler.send(destination: ''),
+        throwsA(TypeMatcher<StompBadStateException>()),
+      );
+      expect(
+        () => handler.ack(id: ''),
+        throwsA(TypeMatcher<StompBadStateException>()),
+      );
+      expect(
+        () => handler.nack(id: ''),
+        throwsA(TypeMatcher<StompBadStateException>()),
+      );
     });
   });
 }

--- a/test/stomp_handler_test.dart
+++ b/test/stomp_handler_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_config.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:stomp_dart_client/stomp_handler.dart';
@@ -83,7 +82,7 @@ void main() {
     });
 
     test('connects correctly', () async {
-      final onConnect = expectAsync2((StompClient? _, StompFrame frame) {
+      final onConnect = expectAsync1((StompFrame frame) {
         expect(frame.command, 'CONNECTED');
         expect(frame.headers.length, 1);
         expect(frame.headers['version'], '1.2');
@@ -108,8 +107,8 @@ void main() {
         count: 1,
       );
 
-      final onConnect = expectAsync2(
-        (StompClient? _, StompFrame frame) {
+      final onConnect = expectAsync1(
+        (StompFrame frame) {
           Timer(Duration(milliseconds: 500), () {
             handler!.dispose();
           });
@@ -145,7 +144,7 @@ void main() {
 
       handler = StompHandler(
         config: config.copyWith(
-          onConnect: (_, frame) {
+          onConnect: (frame) {
             handler!.subscribe(
               destination: '/foo',
               callback: onSubscriptionFrame,
@@ -183,7 +182,7 @@ void main() {
 
       handler = StompHandler(
         config: config.copyWith(
-          onConnect: (StompClient? _, StompFrame frame) {
+          onConnect: (StompFrame frame) {
             final unsubscribe = handler!.subscribe(
               destination: '/foo',
               callback: onSubscriptionFrame,
@@ -225,7 +224,7 @@ void main() {
 
       handler = StompHandler(
         config: config.copyWith(
-          onConnect: (StompClient? _, StompFrame frame) {
+          onConnect: (StompFrame frame) {
             handler!.send(
               destination: '/foo/bar',
               body: 'This is a body',
@@ -253,7 +252,7 @@ void main() {
 
       handler = StompHandler(
         config: config.copyWith(
-          onConnect: (StompClient? _, StompFrame frame) {
+          onConnect: (StompFrame frame) {
             handler!.ack(id: 'message-0', headers: {'receipt': 'send-0'});
           },
           onDisconnect: onDisconnect,
@@ -277,7 +276,7 @@ void main() {
 
       handler = StompHandler(
         config: config.copyWith(
-          onConnect: (StompClient? _, StompFrame frame) {
+          onConnect: (StompFrame frame) {
             handler!.nack(id: 'message-0', headers: {'receipt': 'send-0'});
           },
           onDisconnect: onDisconnect,
@@ -303,7 +302,7 @@ void main() {
 
       handler = StompHandler(
         config: config.copyWith(
-          onConnect: (StompClient? _, StompFrame frame) {
+          onConnect: (StompFrame frame) {
             handler!.subscribe(
               destination: '/bar',
               callback: onSubscriptionFrame,

--- a/test/stomp_parser_test.dart
+++ b/test/stomp_parser_test.dart
@@ -242,7 +242,7 @@ void main() {
           '\r\nMESSAGE\r\ndestination:foo\r\nmessage-id:456\r\n\r\n\x00');
     });
 
-    test('can parse multiple messages seperatley', () {
+    test('can parse multiple messages separately', () {
       final msg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
       final msg2 =
           'MESSAGE\ndestination:bar\nmessage-id:123\n\nThis is a body\x00';

--- a/test/stomp_parser_test.dart
+++ b/test/stomp_parser_test.dart
@@ -10,246 +10,8 @@ void main() {
     test('can parse basic message', () {
       final msg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
 
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 2);
-        expect(frame.headers.containsKey('destination'), isTrue);
-        expect(frame.headers.containsKey('message-id'), isTrue);
-        expect(frame.headers['destination'], 'foo');
-        expect(frame.headers['message-id'], '456');
-        expect(frame.body, isEmpty);
-      }, count: 1);
-
-      final parser = StompParser(callback);
-
-      parser.parseData(msg);
-    });
-
-    test('does not unescape headers (v1.0)', () {
-      final msg = 'MESSAGE\ndesti\\nnation:f\\noo\nmessage-id:456\n\n\x00';
-
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 2);
-        expect(frame.headers.containsKey('desti\\nnation'), isTrue);
-        expect(frame.headers.containsKey('message-id'), isTrue);
-        expect(frame.headers['desti\\nnation'], 'f\\noo');
-        expect(frame.headers['message-id'], '456');
-        expect(frame.body, isEmpty);
-      }, count: 1);
-
-      final parser = StompParser(callback);
-
-      parser.parseData(msg);
-    });
-
-    test('fails on unescaped header values (v1.0)', () {
-      final msg = 'MESSAGE\ndesti\\nnation:f\noo\nmessage-id:456\n\n\x00';
-
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 2);
-        expect(frame.headers.containsKey('desti\\nnation'), isTrue);
-        expect(frame.headers.containsKey('oo\nmessage-id'), isTrue);
-        expect(frame.headers['desti\\nnation'], 'f');
-        expect(frame.headers['oo\nmessage-id'], '456');
-        expect(frame.body, isEmpty);
-      }, count: 1);
-
-      final parser = StompParser(callback);
-
-      parser.parseData(msg);
-    });
-
-    test('does unescape header keys and values (^v1.1)', () {
-      final msg = 'MESSAGE\ndesti\\nnation:f\\noo\nmessage-id:456\n\n\x00';
-
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 2);
-        expect(frame.headers.containsKey('desti\nnation'), isTrue);
-        expect(frame.headers.containsKey('message-id'), isTrue);
-        expect(frame.headers['desti\nnation'], 'f\noo');
-        expect(frame.headers['message-id'], '456');
-        expect(frame.body, isEmpty);
-      }, count: 1);
-
-      final parser = StompParser(callback);
-
-      parser.escapeHeaders = true;
-
-      parser.parseData(msg);
-    });
-
-    test('supports escaped colons in headers (^v1.1)', () {
-      final msg =
-          'MESSAGE\ndestination\\cbar:foo\\cbar\nmessage-id:456\n\n\x00';
-
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 2);
-        expect(frame.headers.containsKey('destination:bar'), isTrue);
-        expect(frame.headers.containsKey('message-id'), isTrue);
-        expect(frame.headers['destination:bar'], 'foo:bar');
-        expect(frame.headers['message-id'], '456');
-        expect(frame.body, isEmpty);
-      }, count: 1);
-
-      final parser = StompParser(callback);
-
-      parser.escapeHeaders = true;
-
-      parser.parseData(msg);
-    });
-
-    test('correctly serializes a stomp frame unescaped', () {
-      final stringFrame =
-          'SEND\ndestination:/path/to/foo\ncontent-type:text/plain\ncontent-length:14\n\nThis is a body\x00';
-      final frame = StompFrame(
-          command: 'SEND',
-          body: 'This is a body',
-          headers: {
-            'destination': '/path/to/foo',
-            'content-type': 'text/plain'
-          });
-
-      final parser = StompParser((_) {});
-
-      final serializedFrame = parser.serializeFrame(frame);
-
-      expect(serializedFrame, stringFrame);
-    });
-
-    test('correctly serializes a stomp frame escaped', () {
-      final stringFrame =
-          'SEND\ndesti\\nnation:/path/to/foo\ncontent-type:te\\nxt/plain\ncontent-length:14\n\nThis is a body\x00';
-      final frame = StompFrame(
-          command: 'SEND',
-          body: 'This is a body',
-          headers: {
-            'desti\nnation': '/path/to/foo',
-            'content-type': 'te\nxt/plain'
-          });
-
-      final parser = StompParser((_) {});
-      parser.escapeHeaders = true;
-
-      final serializedFrame = parser.serializeFrame(frame);
-
-      expect(serializedFrame, stringFrame);
-    });
-
-    test('correctly serializes binary frame', () {
-      final stringFrame =
-          'SEND\ndesti\\nnation:/path/to/foo\ncontent-length:14\n\nThis is a body\x00';
-      final frame = StompFrame(
-          command: 'SEND',
-          binaryBody: Uint8List.fromList('This is a body'.codeUnits),
-          headers: {'desti\nnation': '/path/to/foo'});
-      final parser = StompParser((_) {});
-      parser.escapeHeaders = true;
-
-      final Uint8List serializedFrame = parser.serializeFrame(frame);
-      expect(serializedFrame, Uint8List.fromList(stringFrame.codeUnits));
-
-      final emptyStringFrame = 'SEND\ndesti\\nnation:/path/to/foo\n\n\x00';
-      final emptyBodyFrame = StompFrame(
-          command: 'SEND',
-          binaryBody: Uint8List(0),
-          headers: {'desti\nnation': '/path/to/foo'});
-      final Uint8List emptySerializedFrame =
-          parser.serializeFrame(emptyBodyFrame);
-
-      expect(
-          emptySerializedFrame, Uint8List.fromList(emptyStringFrame.codeUnits));
-    });
-
-    test('can parse frame with empty header', () {
-      final msg = 'MESSAGE\n\nThis is a body\x00';
-
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 0);
-        expect(frame.body, 'This is a body');
-      }, count: 1);
-
-      final parser = StompParser(callback);
-
-      parser.escapeHeaders = true;
-
-      parser.parseData(msg);
-    });
-
-    test('can parse frame with empty header and body', () {
-      final msg = 'MESSAGE\n\n\x00';
-
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 0);
-        expect(frame.body, isEmpty);
-      }, count: 1);
-
-      final parser = StompParser(callback);
-
-      parser.escapeHeaders = true;
-
-      parser.parseData(msg);
-    });
-
-    test('respects content-length when parsing', () {
-      final msg =
-          'MESSAGE\ncontent-length:10\n\nThis is a body longer than 10 bytes\x00';
-
-      var callback = expectAsync1((StompFrame frame) {
-        expect(frame.command, 'MESSAGE');
-        expect(frame.headers.length, 1);
-        expect(frame.headers['content-length'], '10');
-        expect(frame.body, 'This is a ');
-      }, count: 1);
-
-      final parser = StompParser(callback);
-
-      parser.parseData(msg);
-    });
-
-    test('fails silently on wrong content-length', () {
-      final msg = 'MESSAGE\ncontent-length:10\n\nThis is\x00';
-
-      var callback = expectAsync1((frame) {}, count: 0);
-
-      final parser = StompParser(callback);
-
-      parser.parseData(msg);
-    });
-
-    test('can parse ping message', () {
-      dynamic onFrame = expectAsync1((dynamic frame) {}, count: 0);
-      dynamic onPing = expectAsync0(() => null, count: 1);
-
-      final parser = StompParser(onFrame, onPing);
-
-      parser.parseData('\n');
-    });
-
-    test('accepts ping/frames with carriage return', () {
-      dynamic onFrame = expectAsync1((dynamic frame) {}, count: 1);
-      dynamic onPing = expectAsync0(() => null, count: 2);
-
-      final parser = StompParser(onFrame, onPing);
-
-      parser.parseData('\r\n');
-      parser.parseData(
-          '\r\nMESSAGE\r\ndestination:foo\r\nmessage-id:456\r\n\r\n\x00');
-    });
-
-    test('can parse multiple messages separately', () {
-      final msg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
-      final msg2 =
-          'MESSAGE\ndestination:bar\nmessage-id:123\n\nThis is a body\x00';
-
-      var n = 0;
-      dynamic onFrame = expectAsync1((dynamic frame) {
-        if (n == 0) {
+      var callback = expectAsync1(
+        (StompFrame frame) {
           expect(frame.command, 'MESSAGE');
           expect(frame.headers.length, 2);
           expect(frame.headers.containsKey('destination'), isTrue);
@@ -257,22 +19,261 @@ void main() {
           expect(frame.headers['destination'], 'foo');
           expect(frame.headers['message-id'], '456');
           expect(frame.body, isEmpty);
-        } else {
+        },
+        count: 1,
+      );
+
+      StompParser(callback).parseData(msg);
+    });
+
+    test('does not unescape headers (v1.0)', () {
+      final msg = 'MESSAGE\ndesti\\nnation:f\\noo\nmessage-id:456\n\n\x00';
+
+      var callback = expectAsync1(
+        (StompFrame frame) {
           expect(frame.command, 'MESSAGE');
           expect(frame.headers.length, 2);
-          expect(frame.headers.containsKey('destination'), isTrue);
+          expect(frame.headers.containsKey('desti\\nnation'), isTrue);
           expect(frame.headers.containsKey('message-id'), isTrue);
-          expect(frame.headers['destination'], 'bar');
-          expect(frame.headers['message-id'], '123');
+          expect(frame.headers['desti\\nnation'], 'f\\noo');
+          expect(frame.headers['message-id'], '456');
+          expect(frame.body, isEmpty);
+        },
+        count: 1,
+      );
+
+      StompParser(callback).parseData(msg);
+    });
+
+    test('fails on unescaped header values (v1.0)', () {
+      final msg = 'MESSAGE\ndesti\\nnation:f\noo\nmessage-id:456\n\n\x00';
+
+      var callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 2);
+          expect(frame.headers.containsKey('desti\\nnation'), isTrue);
+          expect(frame.headers.containsKey('oo\nmessage-id'), isTrue);
+          expect(frame.headers['desti\\nnation'], 'f');
+          expect(frame.headers['oo\nmessage-id'], '456');
+          expect(frame.body, isEmpty);
+        },
+        count: 1,
+      );
+
+      StompParser(callback).parseData(msg);
+    });
+
+    test('does unescape header keys and values (^v1.1)', () {
+      final msg = 'MESSAGE\ndesti\\nnation:f\\noo\nmessage-id:456\n\n\x00';
+
+      var callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 2);
+          expect(frame.headers.containsKey('desti\nnation'), isTrue);
+          expect(frame.headers.containsKey('message-id'), isTrue);
+          expect(frame.headers['desti\nnation'], 'f\noo');
+          expect(frame.headers['message-id'], '456');
+          expect(frame.body, isEmpty);
+        },
+        count: 1,
+      );
+
+      StompParser(callback)
+        ..escapeHeaders = true
+        ..parseData(msg);
+    });
+
+    test('supports escaped colons in headers (^v1.1)', () {
+      final msg = 'MESSAGE\ndestination\\cbar:foo\\cbar\n'
+          'message-id:456\n\n\x00';
+
+      var callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 2);
+          expect(frame.headers.containsKey('destination:bar'), isTrue);
+          expect(frame.headers.containsKey('message-id'), isTrue);
+          expect(frame.headers['destination:bar'], 'foo:bar');
+          expect(frame.headers['message-id'], '456');
+          expect(frame.body, isEmpty);
+        },
+        count: 1,
+      );
+
+      StompParser(callback)
+        ..escapeHeaders = true
+        ..parseData(msg);
+    });
+
+    test('correctly serializes a stomp frame unescaped', () {
+      final stringFrame =
+          'SEND\ndestination:/path/to/foo\ncontent-type:text/plain'
+          '\ncontent-length:14\n\nThis is a body\x00';
+
+      final frame = StompFrame(
+        command: 'SEND',
+        body: 'This is a body',
+        headers: {'destination': '/path/to/foo', 'content-type': 'text/plain'},
+      );
+
+      final serializedFrame = StompParser((_) {}).serializeFrame(frame);
+      expect(serializedFrame, stringFrame);
+    });
+
+    test('correctly serializes a stomp frame escaped', () {
+      final stringFrame =
+          'SEND\ndesti\\nnation:/path/to/foo\ncontent-type:te\\nxt/plain\n'
+          'content-length:14\n\nThis is a body\x00';
+      final frame = StompFrame(
+        command: 'SEND',
+        body: 'This is a body',
+        headers: {
+          'desti\nnation': '/path/to/foo',
+          'content-type': 'te\nxt/plain',
+        },
+      );
+
+      final parser = StompParser((_) {})..escapeHeaders = true;
+      final serializedFrame = parser.serializeFrame(frame);
+
+      expect(serializedFrame, stringFrame);
+    });
+
+    test('correctly serializes binary frame', () {
+      final stringFrame = 'SEND\ndesti\\nnation:/path/to/foo\n'
+          'content-length:14\n\nThis is a body\x00';
+
+      final frame = StompFrame(
+        command: 'SEND',
+        binaryBody: Uint8List.fromList('This is a body'.codeUnits),
+        headers: {'desti\nnation': '/path/to/foo'},
+      );
+
+      final parser = StompParser((_) {})..escapeHeaders = true;
+      final serializedFrame = parser.serializeFrame(frame);
+
+      expect(serializedFrame, Uint8List.fromList(stringFrame.codeUnits));
+
+      final emptyStringFrame = 'SEND\ndesti\\nnation:/path/to/foo\n\n\x00';
+      final emptyBodyFrame = StompFrame(
+        command: 'SEND',
+        binaryBody: Uint8List(0),
+        headers: {'desti\nnation': '/path/to/foo'},
+      );
+
+      final emptySerializedFrame = parser.serializeFrame(emptyBodyFrame);
+      final codeUnits = Uint8List.fromList(emptyStringFrame.codeUnits);
+      expect(emptySerializedFrame, codeUnits);
+    });
+
+    test('can parse frame with empty header', () {
+      final msg = 'MESSAGE\n\nThis is a body\x00';
+
+      var callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 0);
           expect(frame.body, 'This is a body');
-        }
-        n++;
-      }, count: 2);
+        },
+        count: 1,
+      );
 
-      final parser = StompParser(onFrame);
+      StompParser(callback)
+        ..escapeHeaders = true
+        ..parseData(msg);
+    });
 
-      parser.parseData(msg);
-      parser.parseData(msg2);
+    test('can parse frame with empty header and body', () {
+      final msg = 'MESSAGE\n\n\x00';
+
+      var callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 0);
+          expect(frame.body, isEmpty);
+        },
+        count: 1,
+      );
+
+      StompParser(callback)
+        ..escapeHeaders = true
+        ..parseData(msg);
+    });
+
+    test('respects content-length when parsing', () {
+      final msg = 'MESSAGE\ncontent-length:10\n\n'
+          'This is a body longer than 10 bytes\x00';
+
+      var callback = expectAsync1(
+        (StompFrame frame) {
+          expect(frame.command, 'MESSAGE');
+          expect(frame.headers.length, 1);
+          expect(frame.headers['content-length'], '10');
+          expect(frame.body, 'This is a ');
+        },
+        count: 1,
+      );
+
+      StompParser(callback).parseData(msg);
+    });
+
+    test('fails silently on wrong content-length', () {
+      final msg = 'MESSAGE\ncontent-length:10\n\nThis is\x00';
+      var callback = expectAsync1((frame) {}, count: 0);
+
+      StompParser(callback).parseData(msg);
+    });
+
+    test('can parse ping message', () {
+      final onFrame = expectAsync1((StompFrame frame) {}, count: 0);
+      final onPing = expectAsync0(() => null, count: 1);
+
+      StompParser(onFrame, onPing).parseData('\n');
+    });
+
+    test('accepts ping/frames with carriage return', () {
+      final onFrame = expectAsync1((StompFrame frame) {}, count: 1);
+      final onPing = expectAsync0(() => null, count: 2);
+
+      StompParser(onFrame, onPing)
+        ..parseData('\r\n')
+        ..parseData(
+            '\r\nMESSAGE\r\ndestination:foo\r\nmessage-id:456\r\n\r\n\x00');
+    });
+
+    test('can parse multiple messages separately', () {
+      final msg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
+      final msg2 = 'MESSAGE\ndestination:bar\nmessage-id:123\n\n'
+          'This is a body\x00';
+
+      var n = 0;
+      final onFrame = expectAsync1(
+        (StompFrame frame) {
+          if (n == 0) {
+            expect(frame.command, 'MESSAGE');
+            expect(frame.headers.length, 2);
+            expect(frame.headers.containsKey('destination'), isTrue);
+            expect(frame.headers.containsKey('message-id'), isTrue);
+            expect(frame.headers['destination'], 'foo');
+            expect(frame.headers['message-id'], '456');
+            expect(frame.body, isEmpty);
+          } else {
+            expect(frame.command, 'MESSAGE');
+            expect(frame.headers.length, 2);
+            expect(frame.headers.containsKey('destination'), isTrue);
+            expect(frame.headers.containsKey('message-id'), isTrue);
+            expect(frame.headers['destination'], 'bar');
+            expect(frame.headers['message-id'], '123');
+            expect(frame.body, 'This is a body');
+          }
+          n++;
+        },
+        count: 2,
+      );
+
+      StompParser(onFrame)..parseData(msg)..parseData(msg2);
     });
 
     test('can parse multiple messages at once', () {
@@ -281,43 +282,45 @@ void main() {
           'MESSAGE\ndestination:bar\nmessage-id:123\n\nThis is a body\x00';
 
       var n = 0;
-      dynamic onFrame = expectAsync1((dynamic frame) {
-        if (n == 0) {
-          expect(frame.command, 'MESSAGE');
-          expect(frame.headers.length, 2);
-          expect(frame.headers.containsKey('destination'), isTrue);
-          expect(frame.headers.containsKey('message-id'), isTrue);
-          expect(frame.headers['destination'], 'foo');
-          expect(frame.headers['message-id'], '456');
-          expect(frame.body, isEmpty);
-        } else {
-          expect(frame.command, 'MESSAGE');
-          expect(frame.headers.length, 2);
-          expect(frame.headers.containsKey('destination'), isTrue);
-          expect(frame.headers.containsKey('message-id'), isTrue);
-          expect(frame.headers['destination'], 'bar');
-          expect(frame.headers['message-id'], '123');
-          expect(frame.body, 'This is a body');
-        }
-        n++;
-      }, count: 2);
+      final onFrame = expectAsync1(
+        (StompFrame frame) {
+          if (n == 0) {
+            expect(frame.command, 'MESSAGE');
+            expect(frame.headers.length, 2);
+            expect(frame.headers.containsKey('destination'), isTrue);
+            expect(frame.headers.containsKey('message-id'), isTrue);
+            expect(frame.headers['destination'], 'foo');
+            expect(frame.headers['message-id'], '456');
+            expect(frame.body, isEmpty);
+          } else {
+            expect(frame.command, 'MESSAGE');
+            expect(frame.headers.length, 2);
+            expect(frame.headers.containsKey('destination'), isTrue);
+            expect(frame.headers.containsKey('message-id'), isTrue);
+            expect(frame.headers['destination'], 'bar');
+            expect(frame.headers['message-id'], '123');
+            expect(frame.body, 'This is a body');
+          }
+          n++;
+        },
+        count: 2,
+      );
 
-      final parser = StompParser(onFrame);
-
-      parser.parseData(msg + msg2);
+      StompParser(onFrame).parseData(msg + msg2);
     });
 
     test('can serialize unicode special characters', () {
-      final stringFrame =
-          'SEND\ndesti\\nnation:/path/to/foo\ncontent-length:14\n\n´👌👻¡Â\x00';
-      final frame = StompFrame(
-          command: 'SEND',
-          body: '´👌👻¡Â',
-          headers: {'desti\nnation': '/path/to/foo'});
-      final parser = StompParser((_) {});
-      parser.escapeHeaders = true;
+      final stringFrame = 'SEND\ndesti\\nnation:/path/to/foo\n'
+          'content-length:14\n\n´👌👻¡Â\x00';
 
-      String serializedFrame = parser.serializeFrame(frame);
+      final frame = StompFrame(
+        command: 'SEND',
+        body: '´👌👻¡Â',
+        headers: {'desti\nnation': '/path/to/foo'},
+      );
+
+      final parser = StompParser((_) {})..escapeHeaders = true;
+      final serializedFrame = parser.serializeFrame(frame);
 
       expect(serializedFrame, stringFrame);
       expect(utf8.encode(serializedFrame), utf8.encode(stringFrame));
@@ -328,81 +331,81 @@ void main() {
       final msg2 = 'MESSAGE\ncontent-length:18\n\n{"a": "Piaffe´s"}\x00';
 
       var n = 0;
-      var callback = expectAsync1((StompFrame frame) {
-        if (n == 0) {
-          expect(frame.command, 'MESSAGE');
-          expect(frame.headers.length, 1);
-          expect(frame.headers.containsKey('content-length'), isTrue);
-          expect(frame.headers['content-length'], '23');
-          expect(frame.body, '{"a": "´👌👻¡Â"}');
-          expect(utf8.encode(frame.body!), [
-            123,
-            34,
-            97,
-            34,
-            58,
-            32,
-            34,
-            194,
-            180,
-            240,
-            159,
-            145,
-            140,
-            240,
-            159,
-            145,
-            187,
-            194,
-            161,
-            195,
-            130,
-            34,
-            125
-          ]);
+      var callback = expectAsync1(
+        (StompFrame frame) {
+          if (n == 0) {
+            expect(frame.command, 'MESSAGE');
+            expect(frame.headers.length, 1);
+            expect(frame.headers.containsKey('content-length'), isTrue);
+            expect(frame.headers['content-length'], '23');
+            expect(frame.body, '{"a": "´👌👻¡Â"}');
+            expect(utf8.encode(frame.body!), [
+              123,
+              34,
+              97,
+              34,
+              58,
+              32,
+              34,
+              194,
+              180,
+              240,
+              159,
+              145,
+              140,
+              240,
+              159,
+              145,
+              187,
+              194,
+              161,
+              195,
+              130,
+              34,
+              125
+            ]);
 
-          Map<String, dynamic> jsonMap = json.decode(frame.body!);
-          expect(jsonMap.length, 1);
-          expect(jsonMap['a'], '´👌👻¡Â');
-        } else {
-          expect(frame.command, 'MESSAGE');
-          expect(frame.headers.length, 1);
-          expect(frame.headers.containsKey('content-length'), isTrue);
-          expect(frame.headers['content-length'], '18');
-          expect(frame.body, '{"a": "Piaffe´s"}');
+            final jsonMap = json.decode(frame.body!);
+            expect(jsonMap.length, 1);
+            expect(jsonMap['a'], '´👌👻¡Â');
+          } else {
+            expect(frame.command, 'MESSAGE');
+            expect(frame.headers.length, 1);
+            expect(frame.headers.containsKey('content-length'), isTrue);
+            expect(frame.headers['content-length'], '18');
+            expect(frame.body, '{"a": "Piaffe´s"}');
 
-          expect(utf8.encode(frame.body!), [
-            123,
-            34,
-            97,
-            34,
-            58,
-            32,
-            34,
-            80,
-            105,
-            97,
-            102,
-            102,
-            101,
-            194,
-            180,
-            115,
-            34,
-            125
-          ]);
+            expect(utf8.encode(frame.body!), [
+              123,
+              34,
+              97,
+              34,
+              58,
+              32,
+              34,
+              80,
+              105,
+              97,
+              102,
+              102,
+              101,
+              194,
+              180,
+              115,
+              34,
+              125
+            ]);
 
-          Map<String, dynamic> jsonMap = json.decode(frame.body!);
-          expect(jsonMap.length, 1);
-          expect(jsonMap['a'], 'Piaffe´s');
-        }
-        n++;
-      }, count: 2);
+            final jsonMap = json.decode(frame.body!);
+            expect(jsonMap.length, 1);
+            expect(jsonMap['a'], 'Piaffe´s');
+          }
+          n++;
+        },
+        count: 2,
+      );
 
-      final parser = StompParser(callback);
-
-      parser.parseData(msg);
-      parser.parseData(msg2);
+      StompParser(callback)..parseData(msg)..parseData(msg2);
     });
   });
 }

--- a/test/stomp_parser_test.dart
+++ b/test/stomp_parser_test.dart
@@ -113,7 +113,7 @@ void main() {
             'content-type': 'text/plain'
           });
 
-      final parser = StompParser(null);
+      final parser = StompParser((_) {});
 
       final serializedFrame = parser.serializeFrame(frame);
 
@@ -131,7 +131,7 @@ void main() {
             'content-type': 'te\nxt/plain'
           });
 
-      final parser = StompParser(null);
+      final parser = StompParser((_) {});
       parser.escapeHeaders = true;
 
       final serializedFrame = parser.serializeFrame(frame);
@@ -146,7 +146,7 @@ void main() {
           command: 'SEND',
           binaryBody: Uint8List.fromList('This is a body'.codeUnits),
           headers: {'desti\nnation': '/path/to/foo'});
-      final parser = StompParser(null);
+      final parser = StompParser((_) {});
       parser.escapeHeaders = true;
 
       final Uint8List serializedFrame = parser.serializeFrame(frame);
@@ -314,7 +314,7 @@ void main() {
           command: 'SEND',
           body: '´👌👻¡Â',
           headers: {'desti\nnation': '/path/to/foo'});
-      final parser = StompParser(null);
+      final parser = StompParser((_) {});
       parser.escapeHeaders = true;
 
       String serializedFrame = parser.serializeFrame(frame);

--- a/test/stomp_parser_test.dart
+++ b/test/stomp_parser_test.dart
@@ -10,7 +10,7 @@ void main() {
     test('can parse basic message', () {
       final msg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 2);
         expect(frame.headers.containsKey('destination'), isTrue);
@@ -28,7 +28,7 @@ void main() {
     test('does not unescape headers (v1.0)', () {
       final msg = 'MESSAGE\ndesti\\nnation:f\\noo\nmessage-id:456\n\n\x00';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 2);
         expect(frame.headers.containsKey('desti\\nnation'), isTrue);
@@ -46,7 +46,7 @@ void main() {
     test('fails on unescaped header values (v1.0)', () {
       final msg = 'MESSAGE\ndesti\\nnation:f\noo\nmessage-id:456\n\n\x00';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 2);
         expect(frame.headers.containsKey('desti\\nnation'), isTrue);
@@ -64,7 +64,7 @@ void main() {
     test('does unescape header keys and values (^v1.1)', () {
       final msg = 'MESSAGE\ndesti\\nnation:f\\noo\nmessage-id:456\n\n\x00';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 2);
         expect(frame.headers.containsKey('desti\nnation'), isTrue);
@@ -85,7 +85,7 @@ void main() {
       final msg =
           'MESSAGE\ndestination\\cbar:foo\\cbar\nmessage-id:456\n\n\x00';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 2);
         expect(frame.headers.containsKey('destination:bar'), isTrue);
@@ -167,7 +167,7 @@ void main() {
     test('can parse frame with empty header', () {
       final msg = 'MESSAGE\n\nThis is a body\x00';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 0);
         expect(frame.body, 'This is a body');
@@ -183,7 +183,7 @@ void main() {
     test('can parse frame with empty header and body', () {
       final msg = 'MESSAGE\n\n\x00';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 0);
         expect(frame.body, isEmpty);
@@ -200,7 +200,7 @@ void main() {
       final msg =
           'MESSAGE\ncontent-length:10\n\nThis is a body longer than 10 bytes\x00';
 
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         expect(frame.command, 'MESSAGE');
         expect(frame.headers.length, 1);
         expect(frame.headers['content-length'], '10');
@@ -223,7 +223,7 @@ void main() {
     });
 
     test('can parse ping message', () {
-      dynamic onFrame = expectAsync1((frame) {}, count: 0);
+      dynamic onFrame = expectAsync1((dynamic frame) {}, count: 0);
       dynamic onPing = expectAsync0(() => null, count: 1);
 
       final parser = StompParser(onFrame, onPing);
@@ -232,7 +232,7 @@ void main() {
     });
 
     test('accepts ping/frames with carriage return', () {
-      dynamic onFrame = expectAsync1((frame) {}, count: 1);
+      dynamic onFrame = expectAsync1((dynamic frame) {}, count: 1);
       dynamic onPing = expectAsync0(() => null, count: 2);
 
       final parser = StompParser(onFrame, onPing);
@@ -248,7 +248,7 @@ void main() {
           'MESSAGE\ndestination:bar\nmessage-id:123\n\nThis is a body\x00';
 
       var n = 0;
-      dynamic onFrame = expectAsync1((frame) {
+      dynamic onFrame = expectAsync1((dynamic frame) {
         if (n == 0) {
           expect(frame.command, 'MESSAGE');
           expect(frame.headers.length, 2);
@@ -281,7 +281,7 @@ void main() {
           'MESSAGE\ndestination:bar\nmessage-id:123\n\nThis is a body\x00';
 
       var n = 0;
-      dynamic onFrame = expectAsync1((frame) {
+      dynamic onFrame = expectAsync1((dynamic frame) {
         if (n == 0) {
           expect(frame.command, 'MESSAGE');
           expect(frame.headers.length, 2);
@@ -328,14 +328,14 @@ void main() {
       final msg2 = 'MESSAGE\ncontent-length:18\n\n{"a": "Piaffe´s"}\x00';
 
       var n = 0;
-      var callback = expectAsync1((frame) {
+      var callback = expectAsync1((StompFrame frame) {
         if (n == 0) {
           expect(frame.command, 'MESSAGE');
           expect(frame.headers.length, 1);
           expect(frame.headers.containsKey('content-length'), isTrue);
           expect(frame.headers['content-length'], '23');
           expect(frame.body, '{"a": "´👌👻¡Â"}');
-          expect(utf8.encode(frame.body), [
+          expect(utf8.encode(frame.body!), [
             123,
             34,
             97,
@@ -361,7 +361,7 @@ void main() {
             125
           ]);
 
-          Map<String, dynamic> jsonMap = json.decode(frame.body);
+          Map<String, dynamic> jsonMap = json.decode(frame.body!);
           expect(jsonMap.length, 1);
           expect(jsonMap['a'], '´👌👻¡Â');
         } else {
@@ -371,7 +371,7 @@ void main() {
           expect(frame.headers['content-length'], '18');
           expect(frame.body, '{"a": "Piaffe´s"}');
 
-          expect(utf8.encode(frame.body), [
+          expect(utf8.encode(frame.body!), [
             123,
             34,
             97,
@@ -392,7 +392,7 @@ void main() {
             125
           ]);
 
-          Map<String, dynamic> jsonMap = json.decode(frame.body);
+          Map<String, dynamic> jsonMap = json.decode(frame.body!);
           expect(jsonMap.length, 1);
           expect(jsonMap['a'], 'Piaffe´s');
         }

--- a/test/stomp_test.dart
+++ b/test/stomp_test.dart
@@ -18,18 +18,17 @@ void main() {
       // Setup a server which lets connect and then drops the connection
       var streamChannel = spawnHybridCode(r'''
         import 'dart:io';
-        import 'dart:async';
         import 'package:web_socket_channel/io.dart';
         import 'package:stomp_dart_client/stomp_parser.dart';
         import 'package:stream_channel/stream_channel.dart';
         
-        hybridMain(StreamChannel channel) async {
-          HttpServer server = await HttpServer.bind("localhost", 0);
+        Future<void> hybridMain(StreamChannel channel) async {
+          HttpServer server = await HttpServer.bind('localhost', 0);
           server.transform(WebSocketTransformer()).listen((webSocket) {
             var webSocketChannel = IOWebSocketChannel(webSocket);
             var parser = StompParser((frame) {
               if (frame.command == 'CONNECT') {
-                webSocketChannel.sink.add("CONNECTED\nversion:1.2\n\n\x00");
+                webSocketChannel.sink.add('CONNECTED\nversion:1.2\n\n\x00');
                 webSocketChannel.sink.close();
               } 
             });
@@ -44,10 +43,10 @@ void main() {
 
       int port = await streamChannel.stream.first;
 
-      StompClient client;
+      late StompClient client;
       dynamic onWebSocketDone = expectAsync0(() {}, count: 2);
       var n = 0;
-      dynamic onConnect = expectAsync2((_, frame) {
+      dynamic onConnect = expectAsync2((dynamic _, dynamic frame) {
         if (n == 1) {
           client.deactivate();
         }
@@ -66,13 +65,13 @@ void main() {
 
     test('attempts to reconnect indefinitely when server is unavailable',
         () async {
-      StompClient client;
+      late StompClient client;
       var n = 0;
       dynamic onWebSocketDone = expectAsync0(() {
         if (n == 3) client.deactivate();
         n++;
       }, count: 4);
-      dynamic onConnect = expectAsync2((_, frame) {}, count: 0);
+      dynamic onConnect = expectAsync2((dynamic _, dynamic frame) {}, count: 0);
 
       client = StompClient(
           config: StompConfig(
@@ -120,20 +119,20 @@ void main() {
 
       int port = await streamChannel.stream.first;
 
-      StompClient client;
+      late StompClient client;
       dynamic onWebSocketDone = expectAsync0(() {}, count: 1);
-      dynamic onDisconnect = expectAsync1((frame) {
+      dynamic onDisconnect = expectAsync1((dynamic frame) {
         expect(client.connected, isFalse);
         expect(frame.command, 'RECEIPT');
         expect(frame.headers.length, 1);
         expect(frame.headers['receipt-id'], 'disconnect-0');
       }, count: 1);
-      dynamic onConnect = expectAsync2((_, frame) {
+      dynamic onConnect = expectAsync2((dynamic _, dynamic frame) {
         Timer(Duration(milliseconds: 500), () {
           client.deactivate();
         });
       }, count: 1);
-      dynamic onError = expectAsync1((_) {}, count: 0);
+      dynamic onError = expectAsync1((dynamic _) {}, count: 0);
 
       client = StompClient(
           config: StompConfig(

--- a/test/stomp_test.dart
+++ b/test/stomp_test.dart
@@ -60,7 +60,7 @@ void main() {
       client = StompClient(
         config: StompConfig(
           url: 'ws://localhost:$port',
-          reconnectDelay: 5000,
+          reconnectDelay: Duration(seconds: 5),
           onConnect: onConnect,
           onWebSocketDone: onWebSocketDone,
         ),
@@ -89,9 +89,9 @@ void main() {
         config: StompConfig(
           url: 'ws://localhost:1234',
           onConnect: onConnect,
-          reconnectDelay: 1000,
+          reconnectDelay: Duration(seconds: 1),
           onWebSocketDone: onWebSocketDone,
-          connectionTimeout: Duration(milliseconds: 2000),
+          connectionTimeout: Duration(seconds: 2),
         ),
       )..activate();
     });
@@ -157,7 +157,7 @@ void main() {
       client = StompClient(
         config: StompConfig(
           url: 'ws://localhost:$port',
-          reconnectDelay: 5000,
+          reconnectDelay: Duration(seconds: 5),
           onConnect: onConnect,
           onWebSocketDone: onWebSocketDone,
           onWebSocketError: onError,

--- a/test/stomp_test.dart
+++ b/test/stomp_test.dart
@@ -10,7 +10,7 @@ void main() {
 
     tearDown(() async {});
     test('should not be connected on creation', () {
-      final client = StompClient(config: null);
+      final client = StompClient(config: StompConfig(url: ''));
       expect(client.connected, false);
     });
 

--- a/test/stomp_test.dart
+++ b/test/stomp_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:stomp_dart_client/stomp.dart';
 import 'package:stomp_dart_client/stomp_config.dart';
+import 'package:stomp_dart_client/stomp_exception.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 import 'package:test/test.dart';
 
@@ -229,6 +230,26 @@ void main() {
       );
 
       client = StompClient(config: config)..activate();
+    });
+
+    test('throws when trying to transmit data before activate was called', () {
+      final client = StompClient(config: StompConfig(url: ''));
+      expect(
+        () => client.subscribe(destination: '', callback: (_) {}),
+        throwsA(TypeMatcher<StompBadStateException>()),
+      );
+      expect(
+        () => client.send(destination: ''),
+        throwsA(TypeMatcher<StompBadStateException>()),
+      );
+      expect(
+        () => client.ack(id: ''),
+        throwsA(TypeMatcher<StompBadStateException>()),
+      );
+      expect(
+        () => client.nack(id: ''),
+        throwsA(TypeMatcher<StompBadStateException>()),
+      );
     });
   });
 }

--- a/test/stomp_test.dart
+++ b/test/stomp_test.dart
@@ -47,8 +47,8 @@ void main() {
       final onWebSocketDone = expectAsync0(() {}, count: 2);
 
       var n = 0;
-      final onConnect = expectAsync2(
-        (StompClient? _, StompFrame frame) {
+      final onConnect = expectAsync1(
+        (StompFrame frame) {
           if (n == 1) {
             client.deactivate();
           }
@@ -80,8 +80,8 @@ void main() {
         count: 4,
       );
 
-      final onConnect = expectAsync2(
-        (StompClient? _, StompFrame frame) {},
+      final onConnect = expectAsync1(
+        (StompFrame frame) {},
         count: 0,
       );
 
@@ -147,8 +147,8 @@ void main() {
       );
 
       final onError = expectAsync1((dynamic _) {}, count: 0);
-      final onConnect = expectAsync2(
-        (StompClient? _, StompFrame frame) {
+      final onConnect = expectAsync1(
+        (StompFrame frame) {
           Timer(Duration(milliseconds: 500), () => client.deactivate());
         },
         count: 1,
@@ -209,8 +209,8 @@ void main() {
         count: 1,
       );
 
-      final onConnect = expectAsync2(
-        (StompClient? _, StompFrame frame) {
+      final onConnect = expectAsync1(
+        (StompFrame frame) {
           expect(config.webSocketConnectHeaders?['TEST'], 'DUMMY');
           expect(config.stompConnectHeaders?['TEST'], 'DUMMY');
           Timer(Duration(milliseconds: 500), () => client.deactivate());

--- a/test/test_all.dart
+++ b/test/test_all.dart
@@ -1,3 +1,5 @@
+import 'sock_js_parser_test.dart' as sock_js_parser_test;
+import 'sock_js_utils_test.dart' as sock_js_utils_test;
 import 'stomp_handler_test.dart' as stomp_handler_test;
 import 'stomp_parser_test.dart' as stomp_parser_test;
 import 'stomp_test.dart' as stomp_test;
@@ -7,6 +9,8 @@ import 'stomp_test.dart' as stomp_test;
 /// generate coverage for multiple files. At least that was my expierence
 
 void main() {
+  sock_js_parser_test.main();
+  sock_js_utils_test.main();
   stomp_parser_test.main();
   stomp_handler_test.main();
   stomp_test.main();


### PR DESCRIPTION
Hi there!

I updated stomp_dart_client to support null-safety. Since this is a breaking change anyway and a version bump is recommended, I took the liberty to improve type-safety by removing any incidental dynamic's in the callback function signatures (using typedefs for clarity) and in tests. I also changed the 'int delay params' in the `StompConfig` to `Duration`s and formatted the code. 

All tests are passing and it works within my project. Let me know what you think! 
Cheers :)