### PR TITLE
Treat incoming message body as binary according to 'content-type' header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Stomp Dart
-This library provides an implementation for a STOMP client connecting to a remote server. 
+This library provides an implementation for a STOMP client connecting to a remote server.
 It should work for both pure dart and flutter.
 
 ## Usage
 
 #### Initialize
-The client gets created the specified config, 
+The client gets created the specified config,
 please see the Config section to see all available options
 ```dart
 StompClient client = StompClient(
@@ -100,6 +100,12 @@ StompClient client = StompClient(
 );
 ```
 
+## Evaluation of headers
+
+The STOMP client checks the `content-type` while parsing a received message. If the
+header contains the value `application/octet-stream` the message body will be treated
+as binary data. The resulting `StompFrame` will have a `binaryBody`. The `body` of the
+frame will be empty in this case.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ StompClient client = StompClient(
 The STOMP client checks the `content-type` while parsing a received message. If the
 header contains the value `application/octet-stream` the message body will be treated
 as binary data. The resulting `StompFrame` will have a `binaryBody`. The `body` of the
-frame will be empty in this case.
+frame will be empty in this case. The same is true if the `content-type` header is
+missing.
 
 ## Development
 

--- a/lib/stomp_parser.dart
+++ b/lib/stomp_parser.dart
@@ -178,7 +178,7 @@ class StompParser implements Parser {
   void _consumeBody() {
     final type = _resultHeaders[_CONTENT_TYPE_KEY];
 
-    if (type == _OCTET_STREAM_TYPE) {
+    if (type == _OCTET_STREAM_TYPE || type == null) {
       _binaryBody = Uint8List.fromList(_currentToken);
     } else {
       _resultBody = _consumeTokenAsString();

--- a/test/sock_js_parser_test.dart
+++ b/test/sock_js_parser_test.dart
@@ -7,15 +7,19 @@ import 'package:test/test.dart';
 void main() {
   group('SockJSParser', () {
     test('can parse basic message', () {
-      final stompMsg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
+      final stompMsg = 'MESSAGE\n'
+          'destination:foo\n'
+          'message-id:456\n'
+          'content-type:text/plain\n\n\x00';
       final sockJsMsg = 'm${json.encode(stompMsg)}';
 
       final callback = expectAsync1(
         (StompFrame frame) {
           expect(frame.command, 'MESSAGE');
-          expect(frame.headers.length, 2);
+          expect(frame.headers.length, 3);
           expect(frame.headers.containsKey('destination'), isTrue);
           expect(frame.headers.containsKey('message-id'), isTrue);
+          expect(frame.headers.containsKey('content-type'), isTrue);
           expect(frame.headers['destination'], 'foo');
           expect(frame.headers['message-id'], '456');
           expect(frame.body, isEmpty);
@@ -32,15 +36,19 @@ void main() {
     });
 
     test('can parse array with 1 message', () {
-      final stompMsg = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
+      final stompMsg = 'MESSAGE\n'
+          'destination:foo\n'
+          'message-id:456\n'
+          'content-type:text/plain\n\n\x00';
       final sockJsMsg = 'a[${json.encode(stompMsg)}]';
 
       final callback = expectAsync1(
         (StompFrame frame) {
           expect(frame.command, 'MESSAGE');
-          expect(frame.headers.length, 2);
+          expect(frame.headers.length, 3);
           expect(frame.headers.containsKey('destination'), isTrue);
           expect(frame.headers.containsKey('message-id'), isTrue);
+          expect(frame.headers.containsKey('content-type'), isTrue);
           expect(frame.headers['destination'], 'foo');
           expect(frame.headers['message-id'], '456');
           expect(frame.body, isEmpty);
@@ -57,8 +65,14 @@ void main() {
     });
 
     test('can parse array with 2 messages', () {
-      final stompMsg1 = 'MESSAGE\ndestination:foo\nmessage-id:456\n\n\x00';
-      final stompMsg2 = 'MESSAGE\ndestination:foo\nmessage-id:457\n\n\x00';
+      final stompMsg1 = 'MESSAGE\n'
+          'destination:foo\n'
+          'message-id:456\n'
+          'content-type:text/plain\n\n\x00';
+      final stompMsg2 = 'MESSAGE\n'
+          'destination:foo\n'
+          'message-id:457\n'
+          'content-type:text/plain\n\n\x00';
       final sockJsMsg =
           'a[${json.encode(stompMsg1)},${json.encode(stompMsg2)}]';
       var count = 0;
@@ -66,9 +80,10 @@ void main() {
       final callback = expectAsync1(
         (StompFrame frame) {
           expect(frame.command, 'MESSAGE');
-          expect(frame.headers.length, 2);
+          expect(frame.headers.length, 3);
           expect(frame.headers.containsKey('destination'), isTrue);
           expect(frame.headers.containsKey('message-id'), isTrue);
+          expect(frame.headers.containsKey('content-type'), isTrue);
           expect(frame.headers['destination'], 'foo');
           expect(frame.headers['message-id'], count == 0 ? '456' : '457');
           expect(frame.body, isEmpty);


### PR DESCRIPTION
If an incoming message has a certain content type the body should be treated as binary. ~~The configuration allows to add content types as a list of Strings. A value of 'null' would treat missing 'content-type' headers as having a binary body (this behaviour is mentioned in the STOMP 1.1 spec).~~

The first commit changes the StompParser to treat a message with content type 'application/octet-stream' as having a binary body. This is needed when e.g. working with Spring (here a binaryBody leads to a 'content-type:application/octet-stream').

~~The second commit adds the possibility to configure content types which should lead to a StompFrame with a binary body. This allows more flexibility for different use cases.~~