### PR TITLE
Fixed does not terminate WebSocket connections when the network provider is shut down on IOS

### DIFF
--- a/lib/src/connect_io.dart
+++ b/lib/src/connect_io.dart
@@ -11,7 +11,8 @@ Future<WebSocketChannel> connect(StompConfig config) async {
     var webSocket = WebSocket.connect(
       config.connectUrl,
       headers: config.webSocketConnectHeaders,
-    );
+    ).then((webSocket) => webSocket..pingInterval = config.heartbeatOutgoing);
+
     if (config.connectionTimeout.inMilliseconds > 0) {
       webSocket = webSocket.timeout(config.connectionTimeout);
     }


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/35272
https://github.com/dart-lang/sdk/issues/33362