### PR TITLE
Added Wasm support

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -21,4 +21,4 @@ jobs:
         run: dart analyze
 
       - name: Run tests
-        run: dart test -p "chrome,vm"
+        run: dart test -p "chrome,vm" --compiler chrome:dart2wasm,chrome:dart2js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.2
+  - Fixed oversight in move to `package:web` which made the package not work with wasm.
+
 ## 2.1.1
   - Added `pingInterval` to `StompConfig` to control the ping interval of IO WebSockets. Thanks @AndruhovSasha
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Alternatives are:
 
 #### Running unit tests
 ```dart
-dart run test -p "chrome,vm" test/
+dart run test -p "chrome,vm" --compiler chrome:dart2wasm,chrome:dart2js test/
 ```
 
 #### Generating coverage data

--- a/lib/src/stomp_handler.dart
+++ b/lib/src/stomp_handler.dart
@@ -12,7 +12,7 @@ import 'stomp_frame.dart';
 import 'stomp_parser.dart';
 
 import 'connect_api.dart'
-    if (dart.library.html) 'connect_html.dart'
+    if (dart.library.js_interop) 'connect_html.dart'
     if (dart.library.io) 'connect_io.dart' as platform;
 
 typedef StompUnsubscribe = void Function({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stomp_dart_client
 homepage: https://github.com/blackhorse-one/stomp_dart
-version: 2.1.1
+version: 2.1.2
 description: Dart STOMP client for easy messaging interoperability. Build with flutter in mind, but should work for every dart application.
 environment:
   sdk: ">=2.12.0 <4.0.0"

--- a/test/stomp_config_test.dart
+++ b/test/stomp_config_test.dart
@@ -5,7 +5,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'package:stomp_dart_client/stomp_dart_client.dart';
 import 'package:stomp_dart_client/src/connect_api.dart'
-    if (dart.library.html) 'package:stomp_dart_client/src/connect_html.dart'
+    if (dart.library.js_interop) 'package:stomp_dart_client/src/connect_html.dart'
     if (dart.library.io) 'package:stomp_dart_client/src/connect_io.dart'
     as platform;
 

--- a/test/stomp_handler_test.dart
+++ b/test/stomp_handler_test.dart
@@ -9,7 +9,6 @@ void main() {
     late StompConfig config;
     StompHandler? handler;
     late StreamChannel streamChannel;
-    int? port;
 
     setUpAll(() async {
       // Basic STOMP Server
@@ -69,7 +68,10 @@ void main() {
         stayAlive: true,
       );
 
-      port = await streamChannel.stream.first;
+      dynamic port = await streamChannel.stream.first;
+      if (port is double) {
+        port = port.toInt();
+      }
       config = StompConfig(
         url: 'ws://localhost:$port',
       );

--- a/test/stomp_test.dart
+++ b/test/stomp_test.dart
@@ -67,7 +67,10 @@ void main() {
         stayAlive: true,
       );
 
-      final port = await streamChannel.stream.first;
+      dynamic port = await streamChannel.stream.first;
+      if (port is double) {
+        port = port.toInt();
+      }
       config = StompConfig(
         url: 'ws://localhost:$port',
       );
@@ -120,6 +123,9 @@ void main() {
       );
 
       dynamic customPort = await customChannel.stream.first;
+      if (customPort is double) {
+        customPort = customPort.toInt();
+      }
       late StompClient client;
       final onWebSocketDone = expectAsync0(() {}, count: 2);
 


### PR DESCRIPTION
This was mostly an oversight in the migration to `package:web`. In their migration (https://dart.dev/interop/js-interop/package-web#conditional-imports) they state that:

> However, since dart:html is deprecated and not supported when compiling to Wasm, the correct alternative now is to use dart.library.js_interop to differentiate between native and web:

This was not done in our initial migration and thus Wasm didn't work properly although the code already can. This PR fixes that and also adjusts the test runner & tests themselves to support this.

One note on the test adjustment: The port returned from the hybrid code that simulates a server accepting Stomp connections comes back as a `double` in a Wasm environment and this is why we now check the type of the returned port and convert it accordingly.